### PR TITLE
SearchRouter - fixed wrong yaml configuration example

### DIFF
--- a/de/bundles/Mapbender/CoreBundle/elements/search_router.rst
+++ b/de/bundles/Mapbender/CoreBundle/elements/search_router.rst
@@ -420,16 +420,15 @@ In der mapbender.yml Datei:
 			            buffer: 10    # Puffert die Geometrieergebnise (Karteneinheiten) vor dem Zoomen
 			            minScale: ~   # Maßstabsbegrenzung beim Zoomen, ~ für keine Begrenzung
                         maxScale: ~
-			    results:
-			        styleMap:  # Siehe unten für weitere Styles
-			            default:
-			                strokeColor: '#00ff00'
-			                strokeOpacity: 1
-			                fillOpacity: 0
-			            select:
-			                strokeColor: '#ff0000'
-			                fillColor: '#ff0000'
-			                fillOpacity: 0.4
+               styleMap: # Siehe unten für weitere Styles
+                    default:
+                         strokeColor: '#00ff00'
+                         strokeOpacity: 1
+                         fillOpacity: 0
+                    select:
+                         strokeColor: '#ff0000'
+                         fillColor: '#ff0000'
+                         fillOpacity: 0.4
 
 
 Class, Widget & Style

--- a/en/bundles/Mapbender/CoreBundle/elements/search_router.rst
+++ b/en/bundles/Mapbender/CoreBundle/elements/search_router.rst
@@ -114,22 +114,21 @@ For mapbender.yml:
 			        gid: ID  # column name -> header label
 			        name: Name
 			        type: Type
-			    callback:  # What to do on hover/click
+               callback:  # What to do on hover/click
 			        event: click  # result row event to listen for (click or mouseover)
 			        options:
 			            buffer: 10
 			            minScale: ~  # scale restrictions for zooming, ~ for none
 			            maxScale: ~
-			    results:
-			        styleMap:  # See below
-			            default:
-			                strokeColor: '#00ff00'
-			                strokeOpacity: 1
-			                fillOpacity: 0
-			            select:
-			                strokeColor: '#ff0000'
-			                fillColor: '#ff0000'
-			                fillOpacity: 0.4
+               styleMap:  # See below
+                    default:
+                         strokeColor: '#00ff00'
+                         strokeOpacity: 1
+                         fillOpacity: 0
+                    select:
+                         strokeColor: '#ff0000'
+                         fillColor: '#ff0000'
+                         fillOpacity: 0.4
 
 You need a button to show this element. See :doc:`button` for inherited configuration options.
 


### PR DESCRIPTION
On of the provided yaml example showing the styling of the searchRouter results was not correct.