### PR TITLE
Gitignore - added _ext folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _sources
 .doctrees
 .tox
 .projectile
+_exts


### PR DESCRIPTION
I have added _ext folder to the .gitignore file cause because it was created after the make command and should be part of the repo.