### PR TITLE
Enhanced wording on index page for choosing language

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -3,7 +3,7 @@ Welcome to the Mapbender documentation
 
 Mapbender Project Page https://www.mapbender.org
 
-Please choose a language of your choice:
+Please choose your preferred language:
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
I have changed the wording on the index page. The choice of language IMHO was poorly worded.
From: "Please choose a language of your choice:"
To: "Please choose your preferred language:"

"Please choose a language of your choice:" sounded not so nice to me. Cause choice and choose are from the same stem.

