### PR TITLE
Fixed wrong signature order of listAssets()

### DIFF
--- a/de/customization/templates.rst
+++ b/de/customization/templates.rst
@@ -118,7 +118,7 @@ In der Template-Datei wir der Name des Templates, die Regionen die angelegt werd
  }
  ....
 
- static public function listAssets()
+ public static function listAssets()
  {
         $assets = array(
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss','@WorkshopDemoBundle/Resources/public/demo_fullscreen.css'),
@@ -283,7 +283,7 @@ Fügen Sie die neue CSS-Datei in der Funktion listAssets als letzten Eintrag ein
 .. code-block:: php
 
 
-    static public function listAssets()
+    public static function listAssets()
     {
         $assets = array(
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss','@WorkshopDemoBundle/Resources/public/demo_fullscreen.css'),

--- a/en/customization/templates.rst
+++ b/en/customization/templates.rst
@@ -124,7 +124,7 @@ In the template file you define the name of your template, the regions that you 
  }
  ....
 
- static public function listAssets()
+ public static function listAssets()
  {
         $assets = array(
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss','@WorkshopDemoBundle/Resources/public/demo_fullscreen.css'),
@@ -301,7 +301,7 @@ Add your new css-file to the listAssets function as last array-entry:
 .. code-block:: php
 
 
-    static public function listAssets()
+    public static function listAssets()
     {
         $assets = array(
             'css' => array('@MapbenderCoreBundle/Resources/public/sass/template/fullscreen.scss','@WorkshopDemoBundle/Resources/public/demo_fullscreen.css'),


### PR DESCRIPTION
The signature used for listAssets is wrong. The visibility should stand before the static keyword.
see: http://php.net/manual/de/language.oop5.static.php for reference.