### PR TITLE
added templates for github tickets for mapbender-documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Link to the bug if possible:
 * or at GitHub f.e-: https://github.com/mapbender/mapbender-documentation/blob/master/en/functions/misc/coordinate_utility.rst
 
 **Versions (in which version of the documentation does the error occur):**
- - Mapbender: [e.g. 3.0.6.3]
+ - Mapbender: [e.g. 3.0.8.1]
 
 **Improvement**
 A clear and concise description of what you expected for the documentation. And if possible a better text/screenshot for the documentation

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve the documentation
+
+---
+
+**Describe the bug**
+A clear and concise description of the problem.
+
+Link to the bug if possible:
+* in the documentation https://doc.mapbender.org/en/functions/misc/coordinate_utility.html#using-the-tool
+* or at GitHub f.e-: https://github.com/mapbender/mapbender-documentation/blob/master/en/functions/misc/coordinate_utility.rst
+
+**Versions (in which version of the documentation does the error occur):**
+ - Mapbender: [e.g. 3.0.6.3]
+
+**Improvement**
+A clear and concise description of what you expected for the documentation. And if possible a better text/screenshot for the documentation
+
+
+**Screenshots**
+If it makes sense.
+
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,6 @@ A clear and concise description of what you expected for the documentation. And 
 
 
 **Screenshots**
-If it makes sense.
+Please add a screenshot if it makes sense.
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,3 +16,5 @@ A clear and concise description of any alternative solutions or features you've 
 **Additional context**
 Add any other context or screenshots about the feature request here.
 
+**Screenshots**
+Please add a screenshot if it makes sense.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,17 +4,11 @@ about: Suggest an idea for the documentation
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe your feature request**
+A clear and concise description of what the suggestion
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add any other context about the feature request here.
 
 **Screenshots**
 Please add a screenshot if it makes sense.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for the documentation
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+


### PR DESCRIPTION
* like at the mapbender-issue tracker we could provide templates for bug tickets. See ticket https://github.com/mapbender/mapbender-documentation/issues/67

This PR is a start and for further discussion.