### PR TITLE
3.0.6: Fix/restore composer integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,12 @@
-{	
-    "name": "mapbender/documentation",	
-    "description": "Mapbender documentation",	
-    "keywords": ["mapbender", "documentation"],	
-    "type": "library",	
-    "license": "MIT",	
-    "authors": [	
-        {	
-            "name": "Astrid Emde"	
-        }	
-    ]	
-   
+{
+    "name": "mapbender/documentation",
+    "description": "Mapbender documentation",
+    "keywords": ["mapbender", "documentation"],
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Astrid Emde"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,10 @@
         {
             "name": "Astrid Emde"
         }
-    ]
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-release/3.0.6": "3.0.6.x-dev"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{	
+    "name": "mapbender/documentation",	
+    "description": "Mapbender documentation",	
+    "keywords": ["mapbender", "documentation"],	
+    "type": "library",	
+    "license": "MIT",	
+    "authors": [	
+        {	
+            "name": "Astrid Emde"	
+        }	
+    ]	
+   
+}


### PR DESCRIPTION
Readd deleted composer.json to `release/3.0.6` branch (cherry-pick).  
Provide branch alias so branch head can be installed with a `~3.0.6.0@dev` requirement.