### PR TITLE
Fix/featureinfo

### DIFF
--- a/de/functions/basic/feature_info.rst
+++ b/de/functions/basic/feature_info.rst
@@ -53,12 +53,11 @@ Layer "Krankenhäuser NRW" ist sichtbar und FeatureInfo-Abfrage für den Layer d
 .. image:: ../../../figures/de/feature_info_off.png
      :scale: 80
 
-Layer "Krankenhäuser NRW" ist nicht sichtbar und FeatureInfo-Abfrage für den Layer aktiviert:
+Layer "Krankenhäuser NRW" ist nicht sichtbar, es erfolgt zusätzlich keine FeatureInfo-Abfrage, auch wenn diese aktiviert ist:
 
 .. image:: ../../../figures/de/feature_info_on_layer_invisible.png
      :scale: 80
      
-Obwohl der Layer nicht sichtbar ist, erfolgt in diesem Fall trotzdem die FeatureInfo-Abfrage.
 
 Anzeige als Original und gestyled
 ---------------------------------

--- a/en/functions/basic/feature_info.rst
+++ b/en/functions/basic/feature_info.rst
@@ -48,7 +48,7 @@ The Layer "Krankenhäuser NRW" is visible and the FeatureInfo request for the la
 .. image:: ../../../figures/de/feature_info_off.png
      :scale: 80
 
-The Layer "Krankenhäuser NRW" is invisible and the FeatureInfo request for the same layer is activated.
+The Layer "Krankenhäuser NRW" is invisible and there will be no FeatureInfo request (even if the FeatureInfo request is activated).
 
 .. image:: ../../../figures/de/feature_info_on_layer_invisible.png
      :scale: 80


### PR DESCRIPTION
FeatureInfo changed in Mapbender 3.0.8.5. If a layer is invisible there is no FeatureInfo-request.