### PR TITLE
Sidepane image link fix + Templates.rst link styling

### DIFF
--- a/de/customization/mapbender_templates.rst
+++ b/de/customization/mapbender_templates.rst
@@ -33,22 +33,22 @@ Das Fullscreen Template bietet eine Sidepane an, innerhalb derer Elemente in unt
 
 - "Accordion" zeigt alle hinzugefügten Elemente in Reitern:
 
-.. image:: ../../../figures/sidepane_accordion.png
+.. image:: ../../figures/de/sidepane_accordion.png
      :scale: 80
 
 - "Buttons" zeigt alle hinzugefügten Elemente über Buttons:
 
-.. image:: ../../../figures/sidepane_buttons.png
+.. image:: ../../figures/de/sidepane_buttons.png
      :scale: 80
 
 - "None" verzichtet auf Styling-Optionen und zeigt die Elemente direkt und in der im Backend gewählten Reihenfolge untereinander an:
 
-.. image:: ../../../figures/de/sidepane_nostyle.png
+.. image:: ../../figures/de/sidepane_nostyle.png
      :scale: 80
 
 Die Ansichtsoption für die Sidepane kann im Sidepane-Bereich im Mapbender-Backend ausgewählt werden. Dazu genügt ein Klick auf einen der rechts angeordneten Buttons:
 
-.. image:: ../../../figures/sidepane_backend.png
+.. image:: ../../figures/sidepane_backend.png
      :scale: 80
 
 

--- a/de/customization/templates.rst
+++ b/de/customization/templates.rst
@@ -3,7 +3,7 @@
 Wie werden eigene Style-Vorlagen (templates) erzeugt?
 #####################################################
 
-Mapbender beinhaltet bereits Anwendungs-Vorlagen, sie befinden sich im Mapbender CoreBundle `Template`-Verzeichnis (/application/mapbender/src/Mapbender/CoreBundle/Template). 
+Mapbender beinhaltet bereits Anwendungs-Vorlagen, sie befinden sich im Mapbender CoreBundle `Template`-Verzeichnis (``/application/mapbender/src/Mapbender/CoreBundle/Template``). 
 Häufig sollen jedoch eigene Anwendungs-Vorlagen und Administrationsoberflächen mit eigenem Corporate Design verwendet werden.
 Um Probleme bei einem Upgrade zu vermeiden, sollte für personalisierte Oberflächen ein eigenes Bundle verwendet werden.
 
@@ -98,7 +98,7 @@ In unserem Beispiel erzeugt die Datei *WorkshopDemoBundle.php* einen Namespace f
 Anlegen der eigenen Template-Datei
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In unserem Beispiel heißt die Template-Datei *FullscreenDemo.php*. Sie befindet sich unter src/Workshop/DemoBundle/Template/DemoFullscreen.php.
+In unserem Beispiel heißt die Template-Datei *FullscreenDemo.php*. Sie befindet sich unter ``src/Workshop/DemoBundle/Template/DemoFullscreen.php``.
 
 In der Template-Datei wird der Name des Templates, die Regionen die angelegt werden sollen sowie die verwendete Twig-Datei definiert.
 
@@ -145,11 +145,11 @@ Eigene Twig-Datei erzeugen
 
 Die Twig-Dateien sind im folgenden Verzeichnis gespeichert:
 
-application/mapbender/src/Mapbender/CoreBundle/Resources/views/Template
+``application/mapbender/src/Mapbender/CoreBundle/Resources/views/Template``
 
 Kopieren Sie eine existierende Twig-Datei, speichern Sie diese unter einem neuen Namen und verändern Sie den Inhalt, z.B. die Farbe.
 
-Verwenden Sie z.B. mapbender/src/Mapbender/CoreBundle/Resources/views/Template/fullscreen.html.twig und kopieren Sie diese nach /Workshop/DemoBundle/Resources/views/Template/fullscreen_demo.html.twig
+Verwenden Sie z.B. ``mapbender/src/Mapbender/CoreBundle/Resources/views/Template/fullscreen.html.twig`` und kopieren Sie diese nach ``/Workshop/DemoBundle/Resources/views/Template/fullscreen_demo.html.twig``
 
 
 Eigene CSS-Datei erzeugen
@@ -160,7 +160,7 @@ Es muss lediglich das CSS definiert werden, das vom Standard der Elemente abweic
 
 Mit Hilfe der Entwicklerwerkzeuge Ihres Browsers können Sie die bestehende Definition ermitteln, in Ihre CSS-Datei kopieren und hier anpassen.
 
-Ihre CSS-Datei könnte wie folgt heißen: src/Workshop/DemoBundle/Resources/public/demo_fullscreen.css und die folgende Definition enthalten:
+Ihre CSS-Datei könnte wie folgt heißen: ``src/Workshop/DemoBundle/Resources/public/demo_fullscreen.css`` und die folgende Definition enthalten:
 
 .. code-block:: css
 
@@ -227,7 +227,7 @@ Das Ergebnis der wenigen Zeilen CSS sieht dann so aus:
 
 Beim Laden der neuen Anwendung wird eine CSS-Datei im web/assets-Verzeichnis angelegt:
 
-* web/assets/WorkshopDemoBundle__demo_fullscreen__css.css
+* ``web/assets/WorkshopDemoBundle__demo_fullscreen__css.css``
 
 Wenn Sie die CSS-Datei weiter bearbeiten müssen Sie die unter web/assets generierte Datei löschen, damit diese neu geschrieben wird und die Änderungen wirksam werden. Der Browser-Cache sollte ebenfalls geleert werden.
 
@@ -268,7 +268,7 @@ Registrieren des Bundles in app/AppKernel.php
 
 Bevor Ihre neue Vorlage angezeigt wird, muss diese registriert werden:
 
-* mapbender/app/AppKernel.php
+* ``mapbender/app/AppKernel.php``
 
 .. code-block:: php
 
@@ -319,7 +319,7 @@ Die neue Anwendungs-Vorlage kann über verschiedene Wege verwendet werden:
 Einbindung in YAML-Anwendungen
 ******************************
 
-Sie können nun die YAML-Anwendungen unter app/config/applications anpassen und auf das neue Template verweisen.
+Sie können nun die YAML-Anwendungen unter ``app/config/applications`` anpassen und auf das neue Template verweisen.
 
 .. code-block:: yaml
 
@@ -373,7 +373,7 @@ In der CSS-Datei können Sie zu den Icons der Schriftart folgendermaßen verweis
     content: "\f02f";
   }
 
-Wenn Sie ein Bild nutzen möchten, legen Sie dieses am Besten in Ihrem Bundle ab und referenzieren es auf die folgende Art und Weise:
+Wenn Sie ein Bild nutzen möchten, legen Sie dieses am besten in Ihrem Bundle ab und referenzieren es auf die folgende Art und Weise:
 
 .. code-block:: css
 

--- a/de/customization/templates.rst
+++ b/de/customization/templates.rst
@@ -3,7 +3,7 @@
 Wie werden eigene Style-Vorlagen (templates) erzeugt?
 #####################################################
 
-Mapbender beinhaltet bereits Anwendungs-Vorlagen, sie befinden sich im Mapbender CoreBundle `Template`-Verzeichnis (``/application/mapbender/src/Mapbender/CoreBundle/Template``). 
+Mapbender beinhaltet bereits Anwendungs-Vorlagen, sie befinden sich im Mapbender CoreBundle `Template`-Verzeichnis ``/application/mapbender/src/Mapbender/CoreBundle/Template``. 
 Häufig sollen jedoch eigene Anwendungs-Vorlagen und Administrationsoberflächen mit eigenem Corporate Design verwendet werden.
 Um Probleme bei einem Upgrade zu vermeiden, sollte für personalisierte Oberflächen ein eigenes Bundle verwendet werden.
 
@@ -33,7 +33,7 @@ Sie können sich die Dateien unter folgendem Link herunterladen:
 Erzeugen eines eigenen Bundles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Anwender-Bundles werden im src-Verzeichnis (/application/src) abgelegt.
+Anwender-Bundles werden im src-Verzeichnis ``/application/src`` abgelegt.
 
 Die Struktur eines Bundles kann wie folgt aussehen:
 
@@ -229,7 +229,7 @@ Beim Laden der neuen Anwendung wird eine CSS-Datei im web/assets-Verzeichnis ang
 
 * ``web/assets/WorkshopDemoBundle__demo_fullscreen__css.css``
 
-Wenn Sie die CSS-Datei weiter bearbeiten müssen Sie die unter web/assets generierte Datei löschen, damit diese neu geschrieben wird und die Änderungen wirksam werden. Der Browser-Cache sollte ebenfalls geleert werden.
+Wenn Sie die CSS-Datei weiter bearbeiten müssen Sie die unter ``web/assets`` generierte Datei löschen, damit diese neu geschrieben wird und die Änderungen wirksam werden. Der Browser-Cache sollte ebenfalls geleert werden.
 
 .. code-block:: bash
 
@@ -248,7 +248,7 @@ Passen Sie die vorhandenen CSS-Dateivorlagen für die unterschiedlichen Bereiche
 
 Es muss lediglich das css definiert werden, das vom Standard der Administrationsoberfläche abweicht.
 
-Auf die CSS-Dateien wird über das FOMManagerBundle und FOMUserBundle referenziert. Diese müssen unter app/Resources/ abgelegt werden. Die bereits enthaltenen Twig-Dateien überschreiben nach der erfolgreichen Einrichtung die Standard-Einstellungen (Vorgaben aus der manager.html.twig Datei).
+Auf die CSS-Dateien wird über das FOMManagerBundle und FOMUserBundle referenziert. Diese müssen unter ``app/Resources/`` abgelegt werden. Die bereits enthaltenen Twig-Dateien überschreiben nach der erfolgreichen Einrichtung die Standard-Einstellungen (Vorgaben aus der manager.html.twig Datei).
 Alternativ kann auch die bisherige Twig-Datei kopiert und angepasst werden.
 
 .. code-block:: bash

--- a/en/customization/templates.rst
+++ b/en/customization/templates.rst
@@ -3,7 +3,7 @@
 How to create your own Template?
 ################################
 
-Mapbender comes with application templates out of the box, you can find them in the Mapbender CoreBundle (/application/mapbender/src/Mapbender/CoreBundle/Template). But usually you want to use your own templates with your own corporate design.
+Mapbender comes with application templates out of the box, you can find them in the Mapbender CoreBundle (``/application/mapbender/src/Mapbender/CoreBundle/Template``). But usually you want to use your own templates with your own corporate design.
 
 To prevent overwriting your custom templates after an Mapbender upgrade you should create an extra bundle to safely store your custom files.
 
@@ -36,7 +36,6 @@ User bundles are stored in the src-directory (/application/src).
 
 This is how the structure can look like:
 
-.. code-block:: bash
 
 .. code-block:: bash
 
@@ -72,8 +71,6 @@ Create a new namespace
 The file WorkshopDemoBundle.php creates the namespace for the bundle and refers to the template and to your css-files.
 
 
-
-
 .. code-block:: php
 
     <?php
@@ -97,12 +94,11 @@ The file WorkshopDemoBundle.php creates the namespace for the bundle and refers 
     }
     
    
-    
 
 Create your own template file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In our example the template file is called FullscreenDemo.php. You find it at src/Workshop/DemoBundle/Template/FullscreenDemo.php.
+In our example the template file is called FullscreenDemo.php. You find it at ``src/Workshop/DemoBundle/Template/FullscreenDemo.php``.
 
 In the template file you define the name of your template, the regions that you want to provide and refer to a twig file.
 
@@ -149,11 +145,11 @@ Create your own twig-file
 
 You find the twig-files at the following path:
 
-application/mapbender/src/Mapbender/CoreBundle/Resources/views/Template
+* ``application/mapbender/src/Mapbender/CoreBundle/Resources/views/Template``
 
 The easiest way to create your own twig file is to copy an existing twig, save it under a new name and change the content like colors.
 
-Use the existing template from mapbender/src/Mapbender/CoreBundle/Resources/views/Template/fullscreen.html.twig and copy it to fullscreen_demo.html.twig
+Use the existing template from ``mapbender/src/Mapbender/CoreBundle/Resources/views/Template/fullscreen.html.twig`` and copy it to ``fullscreen_demo.html.twig``.
 
 
 Create your own css-file
@@ -163,7 +159,7 @@ Create an empty css-file and fill it with content. You only have to define the p
 
 Firebug can help you to find out the styles you want to change.
 
-Your file could be named like this: src/Workshop/DemoBundle/Resources/public/demo_fullscreen.css and have the following definition:
+Your file could be named like this: ``src/Workshop/DemoBundle/Resources/public/demo_fullscreen.css`` and have the following definition:
 
 .. code-block:: css
 
@@ -230,7 +226,7 @@ The result of these few lines of css will look like this:
 
 When you open your new application a css-file will be created at:
 
-* web/assets/WorkshopDemoBundle__demo_fullscreen__css.css
+* ``web/assets/WorkshopDemoBundle__demo_fullscreen__css.css``
 
 If you do further edits at your css file you may have to delete the generated css file in the assets directory to see the changes. You should also clear the browser cache.
 
@@ -318,17 +314,16 @@ Now your template should show up in the template list when you create a new appl
 
 How to use a new template
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-There are different ways of how to use the new template
-:
+There are different ways of how to use the new template:
 
 Usage in YAML-applications
 **************************
 
-You can adjust the YAML-applications in app/config/applications and change the templtate parameter.
+You can adjust the YAML-applications in app/config/applications and change the template parameter.
 
 .. code-block:: yaml
 
-  "template:   Workshop\DemoBundle\Template\DemoFullscreen"
+  template:   Workshop\DemoBundle\Template\DemoFullscreen
 
 
 Usage in new applications from the backend
@@ -343,8 +338,6 @@ Usage in an existing application
 For existing applications you can change the parameter in the Mapbender database in the column ``template`` of the table ``mb_core_application``.
 
 For the *WorkshopDemoBundle* you change the entry from ``Mapbender\CoreBundle\Template\Fullscreen`` to ``Workshop\DemoBundle\WorkshopDemoBundle``.
-
-
 
 
 Usecases

--- a/en/customization/templates.rst
+++ b/en/customization/templates.rst
@@ -3,7 +3,7 @@
 How to create your own Template?
 ################################
 
-Mapbender comes with application templates out of the box, you can find them in the Mapbender CoreBundle (``/application/mapbender/src/Mapbender/CoreBundle/Template``). But usually you want to use your own templates with your own corporate design.
+Mapbender comes with application templates out of the box, you can find them in the Mapbender CoreBundle ``/application/mapbender/src/Mapbender/CoreBundle/Template``. But usually you want to use your own templates with your own corporate design.
 
 To prevent overwriting your custom templates after an Mapbender upgrade you should create an extra bundle to safely store your custom files.
 
@@ -32,7 +32,7 @@ To help you we prepared a Workshop/DemoBundle, which can be used not only for ap
 Create your own bundle
 ~~~~~~~~~~~~~~~~~~~~~~
 
-User bundles are stored in the src-directory (/application/src).
+User bundles are stored in the src-directory ``/application/src``.
 
 This is how the structure can look like:
 
@@ -248,7 +248,7 @@ You only have to define the parts that have to look different than the default p
 
 Firebug can help you to find out the styles you want to change.
 
-Referencing the CSS-files is possible with FOMManagerBundle and FOMUserBundle. They must be filed under app/Resources/. The already contained twig-files overwrite the default settings if configured correctly (Requirements from manager.html.twig file).
+Referencing the CSS-files is possible with FOMManagerBundle and FOMUserBundle. They must be filed under ``app/Resources/``. The already contained twig-files overwrite the default settings if configured correctly (Requirements from manager.html.twig file).
 Alternatively, it is possible to copy a twig-file and adjust it afterwards.
 
  .. code-block:: bash


### PR DESCRIPTION
Two things incoming:

1. I fixed the broken image links of the newly added sidepane section in mapbender_templates.rst (for the German version, English worked fine already).

1. I did some cleanup work for templates.rst (both languages), including better styling of file paths, minor typo fixes, and the removal of a duplicate styling box.