### PR TITLE
Placeholder anstatt empty_value

### DIFF
--- a/de/functions/search/search_router.rst
+++ b/de/functions/search/search_router.rst
@@ -68,7 +68,7 @@ Beispiel für ein Feld mit Auswahlmöglichkeiten als Dropdown:
     usertype:                                                         
       type: choice                            # Feld mit Auswahlmöglichkeiten als Dropdown
       options:
-        empty_value: 'Bitte auswählen...'     # Text, der angezeigt wird, bevor etwas ausgewählt wurde
+        placeholder: 'Bitte auswählen...'     # Text, der angezeigt wird, bevor etwas ausgewählt wurde
         choices:                              # die Auswahlmöglichkeiten; werden wie folgt angegeben: "Eintrag in der Spalte der Datenbank": "Angezeiger Name in der Dropdown-Liste"
           1: Company
           2: Administration

--- a/en/functions/search/search_router.rst
+++ b/en/functions/search/search_router.rst
@@ -69,7 +69,7 @@ Example with different selection options via dropdown:
     usertype:                                                         
       type: choice                                                      # box with selection options as dropdown list
       options:
-        placeholder: 'Please select...'                                 # text that is shown before an option is chossen
+        placeholder: 'Please select...'                                 # text that is shown before an option is selected
         choices:                                                        # the options need to be specified: "name of the column of the database": "name shown in the dropdown list"
           1: Company
           2: Administration

--- a/en/functions/search/search_router.rst
+++ b/en/functions/search/search_router.rst
@@ -69,7 +69,7 @@ Example with different selection options via dropdown:
     usertype:                                                         
       type: choice                                                      # box with selection options as dropdown list
       options:
-        empty_value: 'Please select...'                                 # text that is shown before an option is chossen
+        placeholder: 'Please select...'                                 # text that is shown before an option is chossen
         choices:                                                        # the options need to be specified: "name of the column of the database": "name shown in the dropdown list"
           1: Company
           2: Administration


### PR DESCRIPTION
"Empty_value" generates errors starting from Symfony 2.6 and Symfony 3.0. Thus, it was replaced with the command "placeholder".