### PR TITLE
Add components page to TOC

### DIFF
--- a/de/architecture.rst
+++ b/de/architecture.rst
@@ -7,4 +7,5 @@ Architektur
    :maxdepth: 2
 
    architecture/directory_structure
+   architecture/components
    architecture/concepts

--- a/de/architecture/components.rst
+++ b/de/architecture/components.rst
@@ -1,7 +1,7 @@
 .. _components_de:
 
-Mapbender-Komponenten
-#####################
+Komponenten
+###########
 
 Mapbender besteht aus unterschiedlichen Software-Komponenten. Serverseitig wird Symfony als Framework mit seinen integrierten Bestandteilen (Doctrine, Twig, Monolog) genutzt.
 


### PR DESCRIPTION
Small fix to #216 :
After approval, the German page should also appear in the TOC. :gear: 