### PR TITLE
PrintClient page GER & EN

### DIFF
--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -3,25 +3,35 @@
 PrintClient (Druck)
 *******************
 
-Mapbender bietet einen PDF Druck, der einen definierten Bereich der Karte ausdruckt. Hierbei stehen im Client verschiedene Auswahlmöglichkeiten zur Verfügung:
+Der PrintClient ermöglicht den Druck eines vordefinierten Kartenbereichs. Im folgenden wird zunächst der allgemeine Aufbau und die Konfiguration des PrintClients erklärt. Danach folgt eine Einführung in die Erstellung individueller Druckvorlagen. Im letzten Teil wird auf den Druckvorgang selbst eingegangen und wie man diesen konfigurieren kann. 
 
- * Auswahl Druckvorlage,
- * Auswahl Qualität,
- * Auswahl Maßstab,
+
+Allgemeines
+===========
+
+Mit dem PrintClient können folgende Druckeinstellungen beeinflusst werden:
+
+ * Druckvorlage,
+ * Qualität,
+ * Maßstab,
  * Drehung des Ausschnitts,
- * Ausdruck Legende
+ * Titel,
+ * Aktivierung/ Deaktivierung einer Legende,
  * Optional können Textfelder definiert werden (z.B. Titel, Kommentar, Bemerkung), die mit in den Druck übergeben werden.
-
-Der Druck greift auf Druckvorlagen zu, die individuell angepasst werden können. In den Druckvorlagen können Bereiche für Datum, Maßstab, Nordpfeil, Übersichtskarte und dynamische Bild- und Textbereiche definiert werden.
-
-Mapbender bringt bereits eine Kollektion von Druckvorlagen (LibreOffice Draw Dateien in den Formaten A4 bis A0) mit, die individuell angepasst werden können.
 
 .. image:: ../../../figures/de/print_client.png
      :scale: 80
+     
+Das Element kann über einen Button aufgerufen werden oder in der Sidepane als **Element** eingebunden werden. Hier muss der Druckrahmen aktiviert werden, um den Druck zu starten. Nach dem Druck muss der Druckrahmen wieder deaktiviert werden, damit die Karte wie gehabt genutzt werden kann (im Dialog geschieht dies alles durch das Öffnen und Schließen des Dialogfensters).
 
+.. image:: ../../../figures/print_client_sidebar.png
+     :scale: 80     
+     
+Konfiguration des PrintClients
+------------------------------
 
-Konfiguration des Elements
-==========================
+Der PrintClient kann im Backend konfiguriert werden. Er greift dabei auf Druckvorlagen (Templates) zurück. Diese LibreOffice Draw Dateien liegen in den Formaten A4 bis A0 vor. In ihnen können Bereiche für Datum, Maßstab, Nordpfeil, Übersichtskarte und dynamische Bild- und Textbereiche definiert werden.
+
 
 .. image:: ../../../figures/print_client_configuration.png
      :scale: 80
@@ -55,10 +65,6 @@ Im Backend finden Sie die Formularfelder im unteren Teil des Druckdialogs (ein a
 .. image:: ../../../figures/de/print_client_configuration_enhanced.png
      :scale: 80
      
-Das Element kann über einen Button aufgerufen werden oder in der Sidepane als **Element** eingebunden werden. Hier muss der Druckrahmen aktiviert werden, um den Druck zu starten. Nach dem Druck muss der Druckrahmen wieder deaktiviert werden, damit die Karte wie gehabt genutzt werden kann (im Dialog geschieht dies alles durch das Öffnen und Schließen des Dialogfensters).
-
-.. image:: ../../../figures/print_client_sidebar.png
-     :scale: 80
 
 YAML-Definition:
 ----------------
@@ -100,19 +106,22 @@ YAML-Definition:
                 pattern: 'stadtplan.xml'                     # oder es können für den Druck optimierte Dienste angefordert werden.
                 replacement: { 288: 'stadtplan_4.xml' }
 
-
-
 Verzeichnisse
-=============
+-------------
 
-* **northarrow:** Das Bild des Nordpfeils befindet sich unter **app/Resources/MapbenderPrintBundle/images/**. Er kann durch ein anderes Bild ersetzt werden.
+**Der Nordpfeil:**
+* Das Bild des Nordpfeils befindet sich unter **app/Resources/MapbenderPrintBundle/images/**. Er kann durch ein anderes Bild ersetzt werden.
 
-* **print templates:** Die Vorlagen befinden sich unter **app/Resources/MapbenderPrintBundle/templates/**. Es können eigene Druckvorlagen erstellt und hinzugefügt werden.
+**Die Print Templates:**
+* Die Vorlagen befinden sich unter **app/Resources/MapbenderPrintBundle/templates/**. Es können eigene Druckvorlagen erstellt und hinzugefügt werden.
 
-* **Standardverzeichnisse Druck**: Die Druckdateien werden in dem Standard-Downloadordner Ihres Webbrowsers abgelegt. Mapbender speichert die Dateien des Warteschleifendrucks hingegen standardmäßig unter **web/prints/**.
+**Die Druckdateien:**
+* Die Druckdateien werden in dem Standard-Downloadordner Ihres Webbrowsers abgelegt. Mapbender speichert die Dateien des Warteschleifendrucks hingegen standardmäßig unter **web/prints/**.
+
 
 Erstellen einer individuellen Vorlage
 =====================================
+
 Um eine individuelle Druckvorlage zu erstellen, kann eine vorhandene Druckvorlage (ODG-Datei, LibreOffice Draw) kopiert und anschließend bearbeitet werden. Die Vorlage kann feste Objekte wie ein Logo, Copyright oder Druckinformationen beinhalten. Zusätzlich muss eine dynamische Ebene für die dynamisch erzeugten Elemente (wie die Karte, die Übersichtskarte, den Nordpfeil, den Maßstab, das Datum und optionale Felder) erstellt werden. Die dynamische Ebene ist eine zusätzliche nicht druckbare Ebene. Eine Ebene in LibreOffice Draw kann folgendermaßen hinzugefügt werden: **Menü: Einfügen -> Ebene... -> Namen für die Ebene definieren und Checkbox "druckbar" deaktivieren**.
 
 .. image:: ../../../figures/print_template_odg.png
@@ -143,7 +152,7 @@ Das Druck-Skript liest die Informationen (Position, Größe, Schriftgröße, Aus
 
 
 Druck von Elementen vor dem Kartenbild
-======================================
+--------------------------------------
 
 Damit beim Druck der Kartenbereich möglichst groß ist und wenig Platz durch weiße oder leere Bereiche verloren geht, können Elemente vor das Kartenbild gelegt werden. Besonders hilfreich ist dies vor allem bei großen Druckformaten wie DIN A1, die einen verhältnismäßig breiten weißen Rand aufweisen.
 
@@ -173,7 +182,7 @@ Templates anpassen:
 
 
 Legende auf der ersten Seite
-============================
+----------------------------
 
 Neben dem Kartenbereich kann die Legende auf der ersten Seite der Druckvorlage integriert werden. Standardmäßig ist dieser Bereich nicht in den Druckvorlagen vorhanden. Für die Integration der Legende wird die LibreOffice Draw-Druckvorlage angepasst. Hierfür wird ein neues dynamisches Feld mit dem Namen "legend" auf der nicht druckbaren Ebene eingefügt. Die Bezeichnung des Feldes zu "legend" wird über **Menü: Format -> Name…** verändert. Sobald das Element platziert und benannt wurde, wird im Druck die Legende angezeigt. Abschließend muss die ODG-Datei als PDF exportiert und im gleichen Ordner abspeichert werden. Die Legende auf der ersten Seite kann wie folgt aussehen:
 
@@ -182,7 +191,7 @@ Neben dem Kartenbereich kann die Legende auf der ersten Seite der Druckvorlage i
 
 
 Logo auf der Legendenseite
-==========================
+--------------------------
 
 Sofern die Legende weiterhin auf einer zusätzlichen Seite erzeugt werden soll, kann auf der zweiten Seite ebenfalls ein Logo eingebunden werden. Dies erfolgt über das dynamische Element "legendpage_image". Hierfür wird ein neues Feld in der nicht druckbaren Ebene eingefügt, über **Menü: Format -> Name...** in "legendpage_image" umbenannt und an gewünschter Stelle platziert. Das Logo oder Bild wird im Ordner **app/Resources/MapbenderPrintBundle/images/** unter dem Namen "legendpage_image.png" abgespeichert.
 Das erzeugte PDF kann beispielsweise aus folgenden beiden Seiten bestehen:
@@ -193,7 +202,7 @@ Das erzeugte PDF kann beispielsweise aus folgenden beiden Seiten bestehen:
 Auf der zweiten Seite erscheint das eingefügte Logo.
 
 Farbige Texte
-=============
+-------------
 
 Der Text der Druckvorlage kann vielfältig angepasst werden. Neben der Schriftgröße besteht die Möglichkeit, die Farbe des Textes zu verändern. Hierfür wird ein Textfeld erzeugt **Menü: Einfügen -> Textfeld**. Soll der Text als dynamisches Element eingebunden werden, wird dieser auf der vorher festgelegten nicht druckbaren Ebene eingefügt und benannt. Hier wurde als Beispiel das dynamische Element "title" gewählt. Um den Text oder den Platzhalter zu färben, Text innerhalb des Textfeldes (hier: "title") markieren. Die Änderung der Farbe kann rechts neben der Vorlage unterhalb des Reiters **Eigenschaften -> Zeichen** vorgenommen werden.
 
@@ -212,9 +221,8 @@ Die Veränderung der Farbe des dynamischen Feldes "title" in blau kann im Druck 
 
 Analog zu der Veränderung der Schriftfarbe wird auch die Veränderung der Schriftgröße durchgeführt.
 
-
 Dynamische Bilder und dynamische Texte
-======================================
+--------------------------------------
 
 Gruppenabhängig können in der Druckausgabe unterschiedliche Bilder oder Beschreibungen (z.B. Logo und Bezeichnung der Gemeinde) ausgegeben werden. Hierzu gibt es die Platzhalter "dynamic_image" und "dynamic_text". Beide Elemente können in der ODG-Druckvorlage in die nicht druckbare Ebene eingefügt, umbenannt (**Menü: Format -> Name... bzw. Kontextmenü des Elements -> Name...**) und entsprechend platziert werden.
 
@@ -227,19 +235,22 @@ Ein gruppenabhängiger Druck könnte bei einer Gruppe namens "Gruppe 1" wie folg
 
 Zur Nutzung dieser Funktion müssen Gruppen mit Benutzern erstellt und den Anwendungen die jeweiligen Gruppen zugewiesen werden. Weitere Informationen zur Funktionsweise der Gruppen- und Benutzerverwaltung unter `Mapbender Quickstart <../../quickstart.html>`_.
 
-Dynamisches Bild
-----------------
+*Dynamisches Bild*
+------------------
 
 Sobald "dynamic_image" im Drucklayout vorliegt, wird nach einem Bild mit dem Namen der ersten zugewiesenen Gruppe gesucht und dieses im Bereich des Elements "dynamic_image" ausgegeben. Hierbei wird die Höhe zur Orientierung verwendet und die Breite entsprechend angepasst. Die verschiedenen Bilder je Gruppe werden im Ordner **app/Resources/MapbenderPrintBundle/images/** unter dem jeweiligen Namen der Gruppe abgelegt (z.B. Gruppenname ist "Gruppe 1", dann lautet der Name des Bildes Gruppe 1.png).
 
-Dynamischer Text
-----------------
+*Dynamischer Text*
+------------------
 
 Über das Element "dynamic_text" wird die Gruppenbeschreibung der ersten zugewiesenen Gruppe im Ausdruck eingetragen. Das Textfeld verhält sich genauso wie andere Textfelder und kann beliebig viele Zeichen enthalten. Sie können den dynamischen Text unabhängig von dem dynamischen Bild einbinden und bspw. für Copyright-Hinweise nutzen.
 
 
+Der Druckvorgang
+================
+
 Druck von Information für ein ausgewähltes Objekt
-=================================================
+-------------------------------------------------
 
 Es können Informationen zu einem ausgewählten Objekt ausgedruckt werden. Ein Objekt kann über die Digitalisierung (Digitizer) oder die Informationsabfrage (FeatureInfo) selektiert werden.
 
@@ -257,8 +268,8 @@ Die folgenden Schritte müssen durchgeführt werden:
 4. alternativ: Aufruf des Drucks über die Digitalisierung
 
 
-1. Erzeugen einer Druckvorlage, die auf die Objektspalten verweist
-----------------------------------------------------------------------
+*1. Erzeugen einer Druckvorlage, die auf die Objektspalten verweist*
+--------------------------------------------------------------------
 
 Im Drucktemplate ein Textfeld für die Informationen definieren, die für das selektierte Objekt ausdruckt werden sollen. Der Textfeldname hat immer den Prefix *feature.* gefolgt vom Namen der Spalte.
 
@@ -267,8 +278,8 @@ Im Drucktemplate ein Textfeld für die Informationen definieren, die für das se
   feature.name for column name of table poi
 
 
-2. Definition eines featureTypes und Verweis auf das neue Drucktemplate in der config.yml
---------------------------------------------------------------------------------------------------
+*2. Definition eines featureTypes und Verweis auf das neue Drucktemplate in der config.yml*
+-------------------------------------------------------------------------------------------
 
 .. code-block:: yaml
 
@@ -289,8 +300,8 @@ Im Drucktemplate ein Textfeld für die Informationen definieren, die für das se
             label: Demo with feature information print (landscape)
 
 
-3. Aufruf des Drucks über die Informationsabfrage
--------------------------------------------------
+*3. Aufruf des Drucks über die Informationsabfrage*
+---------------------------------------------------
 
 Bemerkung: Die Informationsabfrage (FeatureInfo) ist die Ausgabe von Informationen von einem OGC WMS Service. Sie gibt Informationen zu Objekten an einer Klickposition aus.
 
@@ -314,8 +325,8 @@ Die Informationsabfrage (FeatureInfo) öffnet einen Dialog mit dem Link *print f
 Das gewünschte Gebiet kann auswählt und ein PDF erzeugt werden. Das PDF beinhaltet die Informationen für das selektierte Objekt.
 
 
-4. Oder Aufruf des Drucks über die Digitalisierung
---------------------------------------------------
+*4. Oder Aufruf des Drucks über die Digitalisierung*
+----------------------------------------------------
 
 Die Funktion kann auch in die Digitalisierung eingebunden werden. Im Digitalisierungsdialog wird dann ein neuer Button *Drucken* angeboten.
 
@@ -335,13 +346,13 @@ Bemerkung: Die Flexibilität, den Druckrahmen zu verschieben, hindert den Anwend
 
 
 Warteschleifendruck
-===================
+-------------------
 
 Der Warteschleifendruck ist ein neues Druckfeature in Mapbender, welches einen erweiterten Hintergrunddruck erlaubt. Dieses experimentelle Feature ist seit Mapbender 3.0.8 implementiert. Es ist standardmäßig nicht aktiviert, da bei komplexeren Systemen Probleme mit der Cache-Speicher-Regeneration auftreten können. Sobald aktiviert, kann das Feature entweder händisch über die Kommandozeile angestoßen oder über einen Cronjob automatisiert werden. Der Warteschleifendruck hilft dabei, ressourcenintensive Druckjobs mit langen Ausführungszeiten zu verbessern, indem diese in eine Warteschleife, die im Hintergrund abgearbeitet wird, ausgelagert werden. Währenddessen können Sie mit Mapbender anderweitig weiterarbeiten.
 
 
-1. Warteschleifendruck: Konfiguration
--------------------------------------
+*1. Warteschleifendruck: Konfiguration*
+---------------------------------------
 
 Um den Warteschleifendruck zu aktivieren, muss die parameters.yml-Datei wie folgt ergänzt werden:
 
@@ -354,8 +365,8 @@ Dabei muss "Modus" auf die Option "Warteschleife" gesetzt werden, da sonst stand
 .. image:: ../../../figures/de/print_queue_options.png
      :scale: 80
 
-2. Warteschleifendruck: Kommandozeilenbefehle
----------------------------------------------
+*2. Warteschleifendruck: Kommandozeilenbefehle*
+-----------------------------------------------
 
 Nach Initialisierung des Warteschleifendrucks stehen die folgenden Funktionen über die Kommandozeile zur Ausführung des Drucks zur Verfügung[:]
 
@@ -372,8 +383,8 @@ Nach Initialisierung des Warteschleifendrucks stehen die folgenden Funktionen ü
 Bemerkung: Zur Ausführung der Befehle muss sich der Benutzer im application-Verzeichnis befinden und app/console den jeweiligen Befehlen voranstellen, also bspw.: app/console mapbender:print:queue:clean. Zur genauen Vorgehensweise siehe die Informationen auf der Seite `app/console commands <../../customization/commands.html>`_.
 
 
-3. Warteschleifendruck: Durchführung
-------------------------------------
+*3. Warteschleifendruck: Durchführung*
+--------------------------------------
 
 Der Tab „Einstellungen“ bietet die vom Direktdruck gewohnten Druckoptionen. Nachdem der Warteschleifendruck eingerichtet wurde, kann neben dem Tab „Einstellungen“ über einen Button die neu erscheinende Funktion „Druckaufträge“ angewählt werden. Hier finden sich chronologisch alle Druckaufträge aufgelistet, die der User über das Mapbender-Interface wie gewohnt erstellt.
 
@@ -390,10 +401,10 @@ in der Kommandozeile ausgeführt werden. Er bewirkt, dass nach dem Klick auf den
 
 
 Speicherbegrenzungen
-====================
+--------------------
 
-1. Warteschleifendruck
-----------------------
+*1. Warteschleifendruck*
+------------------------
 
 Da der Druck möglicherweise speicherintensiver sein kann als anfangs in Ihren PHP-Einstellungen festgelegt, kann der benötigte Speicher durch manuelle Konfiguration erhöht werden. Dies ist für Anwender, die mit größeren Ausdrucken arbeiten möchten, besonders von Vorteil.
 Bemerkung: Die Speicherbegrenzung sollte nicht reduziert werden.
@@ -401,8 +412,9 @@ Bemerkung: Die Speicherbegrenzung sollte nicht reduziert werden.
 Der Parameter `mapbender.print.queue.memory_limit` (string; Standard ist 1G) muss angepasst werden, um die Speicherbegrenzung speziell für den Warteschleifendruck zu erhöhen. Vorsicht: Dieser Parameter erlaubt keine "null"-Werte.
 
 
-2. Direktdruck
---------------
+*2. Direktdruck*
+----------------
 
 Über den Parameter `mapbender.print.memory_limit` (string or null; Standard ist null) kann das Speicherlimit angepasst werden (mögliche Werte sind bspw. 512M, 2G, 2048M, etc.).
 Ist der Parameter "null" eingestellt, passt sich der Druck an die vorgegebene php.ini-Begrenzung an, der Wert "-1" steht für unbegrenzte Speichernutzung.
+

--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -3,7 +3,7 @@
 PrintClient (Druck)
 *******************
 
-Der PrintClient ermöglicht den Druck eines vordefinierten Kartenbereichs. Im folgenden wird zunächst der allgemeine Aufbau und die Konfiguration des PrintClients erklärt. Danach folgt eine Einführung in die Erstellung individueller Druckvorlagen. Im letzten Teil wird auf den Druckvorgang selbst eingegangen und wie man diesen konfigurieren kann. 
+Der PrintClient ermöglicht den Druck eines vordefinierten Kartenbereichs. Im Folgenden wird zunächst der allgemeine Aufbau und die Konfiguration des PrintClients erklärt. Danach folgt eine Einführung in die Erstellung individueller Druckvorlagen. Im letzten Teil wird auf den Druckvorgang selbst eingegangen und wie dieser konfiguriert werden kann. 
 
 
 Allgemeines
@@ -22,7 +22,7 @@ Mit dem PrintClient können folgende Druckeinstellungen beeinflusst werden:
 .. image:: ../../../figures/de/print_client.png
      :scale: 80
      
-Das Element kann über einen Button aufgerufen werden oder in der Sidepane als **Element** eingebunden werden. Hier muss der Druckrahmen aktiviert werden, um den Druck zu starten. Nach dem Druck muss der Druckrahmen wieder deaktiviert werden, damit die Karte wie gehabt genutzt werden kann (im Dialog geschieht dies alles durch das Öffnen und Schließen des Dialogfensters).
+Das Element kann über einen Button aufgerufen oder in der Sidepane als Element eingebunden werden. Sobald der PrintClient angesteuert wird, erscheint auf der Karte ein Druckrahmen. Dieser bestimmt den zu druckenden Bereich der Karte und kann vom Anwender beliebig ausgerichtet werden. Nach dem Druck muss der Druckrahmen wieder deaktiviert werden, damit die Karte wie gehabt genutzt werden kann (im Dialog geschieht dies alles durch das Öffnen und Schließen des Dialogfensters).
 
 .. image:: ../../../figures/print_client_sidebar.png
      :scale: 80     
@@ -66,8 +66,8 @@ Im Backend finden Sie die Formularfelder im unteren Teil des Druckdialogs (ein a
      :scale: 80
      
 
-YAML-Definition:
-----------------
+YAML-Definition
+---------------
 
 .. code-block:: yaml
 
@@ -265,7 +265,7 @@ Die folgenden Schritte müssen durchgeführt werden:
 1. Erzeugen eines Drucktemplates, das auf die Objektspalten verweist
 2. Definition eines featureTypes und Verweis auf das neue Drucktemplate in der config.yml
 3. Druck über die Informationsabfrage aufrufen
-4. alternativ: Aufruf des Drucks über die Digitalisierung
+4. Alternativ: Aufruf des Drucks über die Digitalisierung
 
 
 *1. Erzeugen einer Druckvorlage, die auf die Objektspalten verweist*
@@ -325,8 +325,8 @@ Die Informationsabfrage (FeatureInfo) öffnet einen Dialog mit dem Link *print f
 Das gewünschte Gebiet kann auswählt und ein PDF erzeugt werden. Das PDF beinhaltet die Informationen für das selektierte Objekt.
 
 
-*4. Oder Aufruf des Drucks über die Digitalisierung*
-----------------------------------------------------
+*4. Alternativ: Aufruf des Drucks über die Digitalisierung*
+-----------------------------------------------------------
 
 Die Funktion kann auch in die Digitalisierung eingebunden werden. Im Digitalisierungsdialog wird dann ein neuer Button *Drucken* angeboten.
 
@@ -351,8 +351,8 @@ Warteschleifendruck
 Der Warteschleifendruck ist ein neues Druckfeature in Mapbender, welches einen erweiterten Hintergrunddruck erlaubt. Dieses experimentelle Feature ist seit Mapbender 3.0.8 implementiert. Es ist standardmäßig nicht aktiviert, da bei komplexeren Systemen Probleme mit der Cache-Speicher-Regeneration auftreten können. Sobald aktiviert, kann das Feature entweder händisch über die Kommandozeile angestoßen oder über einen Cronjob automatisiert werden. Der Warteschleifendruck hilft dabei, ressourcenintensive Druckjobs mit langen Ausführungszeiten zu verbessern, indem diese in eine Warteschleife, die im Hintergrund abgearbeitet wird, ausgelagert werden. Währenddessen können Sie mit Mapbender anderweitig weiterarbeiten.
 
 
-*1. Warteschleifendruck: Konfiguration*
----------------------------------------
+*Warteschleifendruck: Konfiguration*
+------------------------------------
 
 Um den Warteschleifendruck zu aktivieren, muss die parameters.yml-Datei wie folgt ergänzt werden:
 
@@ -365,8 +365,8 @@ Dabei muss "Modus" auf die Option "Warteschleife" gesetzt werden, da sonst stand
 .. image:: ../../../figures/de/print_queue_options.png
      :scale: 80
 
-*2. Warteschleifendruck: Kommandozeilenbefehle*
------------------------------------------------
+*Warteschleifendruck: Kommandozeilenbefehle*
+--------------------------------------------
 
 Nach Initialisierung des Warteschleifendrucks stehen die folgenden Funktionen über die Kommandozeile zur Ausführung des Drucks zur Verfügung[:]
 
@@ -383,8 +383,8 @@ Nach Initialisierung des Warteschleifendrucks stehen die folgenden Funktionen ü
 Bemerkung: Zur Ausführung der Befehle muss sich der Benutzer im application-Verzeichnis befinden und app/console den jeweiligen Befehlen voranstellen, also bspw.: app/console mapbender:print:queue:clean. Zur genauen Vorgehensweise siehe die Informationen auf der Seite `app/console commands <../../customization/commands.html>`_.
 
 
-*3. Warteschleifendruck: Durchführung*
---------------------------------------
+*Warteschleifendruck: Durchführung*
+-----------------------------------
 
 Der Tab „Einstellungen“ bietet die vom Direktdruck gewohnten Druckoptionen. Nachdem der Warteschleifendruck eingerichtet wurde, kann neben dem Tab „Einstellungen“ über einen Button die neu erscheinende Funktion „Druckaufträge“ angewählt werden. Hier finden sich chronologisch alle Druckaufträge aufgelistet, die der User über das Mapbender-Interface wie gewohnt erstellt.
 
@@ -403,8 +403,8 @@ in der Kommandozeile ausgeführt werden. Er bewirkt, dass nach dem Klick auf den
 Speicherbegrenzungen
 --------------------
 
-*1. Warteschleifendruck*
-------------------------
+*Warteschleifendruck*
+---------------------
 
 Da der Druck möglicherweise speicherintensiver sein kann als anfangs in Ihren PHP-Einstellungen festgelegt, kann der benötigte Speicher durch manuelle Konfiguration erhöht werden. Dies ist für Anwender, die mit größeren Ausdrucken arbeiten möchten, besonders von Vorteil.
 Bemerkung: Die Speicherbegrenzung sollte nicht reduziert werden.
@@ -412,8 +412,8 @@ Bemerkung: Die Speicherbegrenzung sollte nicht reduziert werden.
 Der Parameter `mapbender.print.queue.memory_limit` (string; Standard ist 1G) muss angepasst werden, um die Speicherbegrenzung speziell für den Warteschleifendruck zu erhöhen. Vorsicht: Dieser Parameter erlaubt keine "null"-Werte.
 
 
-*2. Direktdruck*
-----------------
+*Direktdruck*
+-------------
 
 Über den Parameter `mapbender.print.memory_limit` (string or null; Standard ist null) kann das Speicherlimit angepasst werden (mögliche Werte sind bspw. 512M, 2G, 2048M, etc.).
 Ist der Parameter "null" eingestellt, passt sich der Druck an die vorgegebene php.ini-Begrenzung an, der Wert "-1" steht für unbegrenzte Speichernutzung.

--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -16,7 +16,7 @@ Mit dem PrintClient können folgende Druckeinstellungen beeinflusst werden:
  * Maßstab,
  * Drehung des Ausschnitts,
  * Titel,
- * Aktivierung/ Deaktivierung einer Legende,
+ * Aktivierung/Deaktivierung einer Legende,
  * Optional können Textfelder definiert werden (z.B. Titel, Kommentar, Bemerkung), die mit in den Druck übergeben werden.
 
 .. image:: ../../../figures/de/print_client.png

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -15,7 +15,7 @@ It is possible to define different properties of the PDF you would like to print
  * Quality,
  * Scale,
  * Frame rotation,
- * Activate/ deactivate legend
+ * Activate/deactivate legend
  * Optionally, it is possible to define individual input fields (e.g. title, comment, remark), which will then also be printed in the PDF.
 
 .. image:: ../../../figures/print_client.png
@@ -30,7 +30,7 @@ The PrintClient element can be implemented both as a dialog (via a button) and a
 Configuration
 -------------
 
-The Printclient can be configurated in the backend. It relies on print templates (format A4 to A0). These LibreOffice Draw files can be individually modified regarding the location of date, scale, north arrow, overview map as well as dynamic images/ texts in the PDF.
+The Printclient can be configurated in the backend. It relies on print templates (format A4 to A0). These LibreOffice Draw files can be individually modified regarding the location of date, scale, north arrow, overview map as well as dynamic images/texts in the PDF.
 
 .. image:: ../../../figures/print_client_configuration.png
      :scale: 80

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -4,7 +4,7 @@
 PrintClient
 ************
 
-The PrintClient allows for the print of a predefined map area. The following documentation will first give an overview about the general set-up and configuration of the PrintClient. The second part will answer the question, how individual print templates can be generated. Lastly, the print process and all its configuration options will be presented.
+The PrintClient allows for the print of a predefined map area. The following documentation will first give an overview about the general set-up and configuration of the PrintClient. The second part will answer the question how individual print templates can be generated. Lastly, the print process and all its configuration options will be presented.
 
 General
 =======
@@ -21,7 +21,7 @@ It is possible to define different properties of the PDF you would like to print
 .. image:: ../../../figures/print_client.png
      :scale: 80
 
-The PrintClient element can be implemented both as a dialog (via a button) and as element as part of the sidepane. If it is part of the sidepane, you have to activate the print frame first to start the print. When finished, you have to deactivate the print frame to use the map as usual again (when used as a dialog this happens automatically by opening and closing the dialog window).
+The PrintClient element can be implemented both as a dialog (via a button) and as element as part of the sidepane. If it is part of the sidepane, you have to activate the print frame first to start the print. The print frame can be moved around freely in the map canvas, it defines the area of the PDF output. When finished, you have to deactivate the print frame to use the map as usual again (when used as a dialog this happens automatically by opening and closing the dialog window).
 
 .. image:: ../../../figures/print_client_sidebar.png
      :scale: 80     :scale: 80
@@ -30,7 +30,7 @@ The PrintClient element can be implemented both as a dialog (via a button) and a
 Configuration
 -------------
 
-The Printclient can be configurated in the backend. It relies on print templates (format A4 to A0). These LibreOffice Draw files can be individually modified regarding the location of date, scale, north arrow, overview map as well as dynamic images/texts in the PDF.
+The Printclient can be configurated in the backend. It relies on print templates (format A0 to A4). These LibreOffice Draw files can be individually modified regarding the location of date, scale, north arrow, overview map as well as dynamic images/texts in the PDF.
 
 .. image:: ../../../figures/print_client_configuration.png
      :scale: 80
@@ -65,8 +65,8 @@ Here's an example for the backend configuration (or look below in the YAML defin
      :scale: 80
 
 
-YAML-Definition:
-----------------
+YAML-Definition
+---------------
 
 .. code-block:: yaml
 
@@ -337,8 +337,8 @@ Queued Print
 The queued print is an experimental print feature for Mapbender which comes with an advanced background print system. Right now, it's still in experimental state due to several potential cache memory regeneration problems on more complex server structures. The queued print is implemented since Mapbender 3.0.8, but deactivated by default. If you choose to activate it, you can use the feature via command line (either manually or as a cronjob). Queued print helps improving resource-intense print jobs, because the queue can manage the print jobs more easily in the background (compared to direct print). In the meantime, you're free to work with Mapbender in other ways.
 
 
-*1. Queued print: Configuration*
---------------------------------
+*Queued print: Configuration*
+-----------------------------
 
 To activate the queued print, open the parameters.yml file of your Mapbender installation and insert the following parameter:
 
@@ -353,8 +353,8 @@ Open your PrintClient element and adjust the new options "Mode" and "Job queue".
 .. image:: ../../../figures/print_queue_options.png
      :scale: 80
 
-*2. Queued print: Bash commands*
---------------------------------
+*Queued print: Bash commands*
+-----------------------------
 
 After the setup, the queued print can be controlled with several bash commands, which are as follows:
 
@@ -371,8 +371,8 @@ After the setup, the queued print can be controlled with several bash commands, 
 Note: To run the commands, open a terminal and head to the Mapbender application directory. Then, execute a command like this: 'app/console mapbender:print:queue:clean'. Detailed information on the commands:  `app/console commands <../../customization/commands.html>`_.
 
 
-*3. Queued print: Usage*
-------------------------
+*Queued print: Usage*
+---------------------
 
 When using the queued print in the frontend, there are two options: The tab "Job settings" offers the same print settings as the direct print. If the queued print has been set up right, a tab called 'Recent jobs' appears next to the 'Job settings' tab. If this tab is chosen, a chronological list of your print jobs will be shown. A new job will appear in the list after the "Print" button is clicked.
 
@@ -391,8 +391,8 @@ to execute a print process in the command line. This process starts all the jobs
 Memory Limits
 -------------
 
-*1. Queued Print*
------------------
+*Queued Print*
+--------------
 
 Print jobs can be resource intensive and may exceed your initially set php.ini memory limit. Therefore it is possible to increase the required memory limit manually. This is an advantage for users who are working with large print templates.
 Note: Never reduce the memory limit.
@@ -400,8 +400,8 @@ Note: Never reduce the memory limit.
 To increase the memory limits for the queued print, adjust `mapbender.print.queue.memory_limit` (string; default is 1G). Caution: This parameter does not allow 'null' as value.
 
 
-*2. Direct Print*
------------------
+*Direct Print*
+--------------
 
 To increase the memory limit of the direct print, adjust `mapbender.print.memory_limit` (string or null; default is null) to your possible memory contigent.
 If the parameter is set to 'null', Mapbender print will look for your php.ini value.

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -4,24 +4,33 @@
 PrintClient
 ************
 
-Mapbender offers a PDF print which prints a defined area of the map. Before you print, you can choose from these different possibilities with the client:
+The PrintClient allows for the print of a predefined map area. The following documentation will first give an overview about the general set-up and configuration of the PrintClient. The second part will answer the question, how individual print templates can be generated. Lastly, the print process and all its configuration options will be presented.
 
- * select scale,
- * select quality,
- * rotate the print frame,
- * print legend
- * optionally, it is possible to define individual input fields (e.g. title, comment, remark), which will also be printed in the PDF.
+General
+=======
 
-The print element uses print templates, which can be modified individually. In the print templates, you can define regions for date, scale (text or scalebar), north arrow, overview map and dynamic images / dynamic texts.
+It is possible to define different properties of the PDF you would like to print with the client:
 
-Mapbender already contains a collection of print templates (LibreOffice Draw files in formats A4 to A0) which can be modified individually.
+ * Print template,
+ * Quality,
+ * Scale,
+ * Frame rotation,
+ * Activate/ deactivate legend
+ * Optionally, it is possible to define individual input fields (e.g. title, comment, remark), which will then also be printed in the PDF.
 
 .. image:: ../../../figures/print_client.png
      :scale: 80
 
+The PrintClient element can be implemented both as a dialog (via a button) and as element as part of the sidepane. If it is part of the sidepane, you have to activate the print frame first to start the print. When finished, you have to deactivate the print frame to use the map as usual again (when used as a dialog this happens automatically by opening and closing the dialog window).
+
+.. image:: ../../../figures/print_client_sidebar.png
+     :scale: 80     :scale: 80
+
 
 Configuration
-=============
+-------------
+
+The Printclient can be configurated in the backend. It relies on print templates (format A4 to A0). These LibreOffice Draw files can be individually modified regarding the location of date, scale, north arrow, overview map as well as dynamic images/ texts in the PDF.
 
 .. image:: ../../../figures/print_client_configuration.png
      :scale: 80
@@ -55,10 +64,6 @@ Here's an example for the backend configuration (or look below in the YAML defin
 .. image:: ../../../figures/print_client_configuration_enhanced.png
      :scale: 80
 
-The PrintClient element can be implemented both as a dialog (via a button) and as element as part of the sidepane. If it is part of the sidepane, you have to activate the print frame first to start the print. When finished, you have to deactivate the print frame to use the map as usual again (when used as a dialog this happens automatically by opening and closing the dialog window).
-
-.. image:: ../../../figures/print_client_sidebar.png
-     :scale: 80     :scale: 80
 
 YAML-Definition:
 ----------------
@@ -99,15 +104,18 @@ YAML-Definition:
                 pattern: 'stadtplan.xml'        # or you can request a different service which is optimized for printing
                 replacement: { 288: 'stadtplan_4.xml' }
 
-
 Directories
-=============
+-----------
 
-* **northarrow:** The "north arrow" image is located at **app/Resources/MapbenderPrintBundle/images/**. The "north arrow" image can be replaced to use a different image instead.
+**The northarrow**
+* The "north arrow" image is located at **app/Resources/MapbenderPrintBundle/images/**. The "north arrow" image can be replaced to use a different image instead.
 
-* **print templates:** The print templates can be found under **app/Resources/MapbenderPrintBundle/templates/**. 
+**The print templates**
+* The print templates can be found under **app/Resources/MapbenderPrintBundle/templates/**. 
 
-* **default directories**: Mapbender saves its generated print files in the browser's default download folder. If the queued print is used, the files will be saved under the Mapbender directory **web/prints/**.
+**The print files**
+Mapbender saves its generated print files in the browser's default download folder. If the queued print is used, the files will be saved under the Mapbender directory **web/prints/**.
+
 
 Create your individual templates
 ================================
@@ -142,7 +150,7 @@ Export the template to .pdf under the same name as the .odg file. Use the name w
 The print script will read the information (position, size, font size, alignment) from the .odg-file and combines those with the fixed objects in the PDF template and the map image in Mapbender to generate your PDF.
 
 Printing elements in front of the map element
-=============================================
+---------------------------------------------
 
 In order for the map element to be as large as possible and to avoid white or empty areas, elements can be placed in front of the map image to prevent that space is lost through white areas. This is particularly useful in the case of large printing formats which have a comparatively wide border.
 
@@ -172,7 +180,7 @@ Adapt templates:
 
 
 Legend on the first page
-========================
+------------------------
 
 The legend can be integrated next to the map on the first page. This field is not included in the print template by default. To insert the legend the ODG print template file needs to be modified. A new dynamic field with the name "legend" on the non printable layer needs to be inserted. **Menu: Modify -> Name...** to change the name of the field to "legend". As final step,  the ODG-file has to be exported as PDF-file as described above and saved in the same directory. The result could look like this:
 
@@ -180,8 +188,8 @@ The legend can be integrated next to the map on the first page. This field is no
     :scale: 80
 
 
-Logo on the legendpage
-======================
+Logo on the legend page
+-----------------------
 
 If the legend shall be created on an additional page, the logo can be placed on this page too. This can be achieved with the dynamic element "legendpage_image". A new field on the non-printable layer has to be created and the name changed to "legendpage_image" (**Menu: Modify -> Name...**). The desired logo or image has to be saved in the directory **app/Resources/MapbenderPrintBundle/images/** and its name needs to be changed to "legendpage_image.png". 
 
@@ -190,7 +198,7 @@ If the legend shall be created on an additional page, the logo can be placed on 
 
 
 Coloured texts
-==============
+--------------
 
 The text in the print template can be changed in many ways. Besides the size of the font, one can also change the colour of the text. To do so, a text field via **Menu: Insert -> Text Box** needs to be inserted. To change the colour of the text, select the text in the text field (here: "title"). The colour can be changed in the tab **Properties -> Character**:
 
@@ -210,7 +218,7 @@ The change of the colour of the dynamic field "title" to blue can look like this
 The change of the font size works in an analogous manner.
 
 Dynamic images and dynamic texts
-================================
+--------------------------------
 
 Dependent on a group, prints can be created with different logos and texts (e.g. the name of the commune and the individual logo). There are two objects which can handle this: "dynamic_image" and "dynamic_text". If these objects exist in the print layout [Mapbender and the user are members of a group], Mapbender will then search for an image with the name of the group (groupname.png). The picture will be displayed in the print in the object ["dynamic_image"]. The height of the object will be used to scale the image[,] the width will be calculated relative to the height. In the object ["dynamic_text"] the group description will be printed.
 
@@ -229,8 +237,11 @@ The description of the group will be displayed in the field "dynamic_text" (e.g.
 The element "dynamic_text" looks for a group description that is given in the first assigned group of the print. You can implement the dynamic text independently from the dynamic image. 
 
 
+The printing process
+====================
+
 Printing feature information for a selected element
-===================================================
+---------------------------------------------------
 
 A feature can be selected via digitizer or Feature Info.
 
@@ -247,8 +258,8 @@ There are some steps you have to follow:
 3. Call feature print from FeatureInfo
 4. Or call feature print from digitizer
 
-1. Create a print template that refers to the feature columns
--------------------------------------------------------------
+*1. Create a print template that refers to the feature columns*
+---------------------------------------------------------------
 
 Define text fields in the print template for every information you would like to print for the selected object. The text field name has always the prefix *feature.*, followed with the name of the attribute (column) to export.
 
@@ -257,8 +268,8 @@ Define text fields in the print template for every information you would like to
  feature.name for column name of table poi
 
 
-2. Define a featureType and refer to your new print template in your config.yml
--------------------------------------------------------------------------------
+*2. Define a featureType and refer to your new print template in your config.yml*
+---------------------------------------------------------------------------------
 
 .. code-block:: yaml
 
@@ -279,8 +290,8 @@ Define text fields in the print template for every information you would like to
             label: Demo with feature information print (landscape)
 
 
-3. Call feature print from FeatureInfo
---------------------------------------
+*3. Call feature print from FeatureInfo*
+----------------------------------------
 
 Note: FeatureInfo is the information output from a OGC WMS service. It offers information for features at a click position.
 
@@ -304,8 +315,8 @@ The FeatureInfo will open a dialog with a link *print feature information*. When
 You can choose the desired region and create a print PDF. The PDF will contain the information for the selected feature.
 
 
-4. Or call feature print from digitizer
-----------------------------------------
+*4. Or call feature print from digitizer*
+-----------------------------------------
 
 The functionality can also be integrated in the digitizer. It will offer a new button *print* in every feature information dialog.
 
@@ -321,13 +332,13 @@ Note: The flexibility to move the print frame won‘t stop you from choosing a r
 
 
 Queued Print
-============
+------------
 
 The queued print is an experimental print feature for Mapbender which comes with an advanced background print system. Right now, it's still in experimental state due to several potential cache memory regeneration problems on more complex server structures. The queued print is implemented since Mapbender 3.0.8, but deactivated by default. If you choose to activate it, you can use the feature via command line (either manually or as a cronjob). Queued print helps improving resource-intense print jobs, because the queue can manage the print jobs more easily in the background (compared to direct print). In the meantime, you're free to work with Mapbender in other ways.
 
 
-1. Queued print: Configuration
-------------------------------
+*1. Queued print: Configuration*
+--------------------------------
 
 To activate the queued print, open the parameters.yml file of your Mapbender installation and insert the following parameter:
 
@@ -342,8 +353,8 @@ Open your PrintClient element and adjust the new options "Mode" and "Job queue".
 .. image:: ../../../figures/print_queue_options.png
      :scale: 80
 
-2. Queued print: Bash commands
-------------------------------
+*2. Queued print: Bash commands*
+--------------------------------
 
 After the setup, the queued print can be controlled with several bash commands, which are as follows:
 
@@ -360,8 +371,8 @@ After the setup, the queued print can be controlled with several bash commands, 
 Note: To run the commands, open a terminal and head to the Mapbender application directory. Then, execute a command like this: 'app/console mapbender:print:queue:clean'. Detailed information on the commands:  `app/console commands <../../customization/commands.html>`_.
 
 
-3. Queued print: Usage
-----------------------
+*3. Queued print: Usage*
+------------------------
 
 When using the queued print in the frontend, there are two options: The tab "Job settings" offers the same print settings as the direct print. If the queued print has been set up right, a tab called 'Recent jobs' appears next to the 'Job settings' tab. If this tab is chosen, a chronological list of your print jobs will be shown. A new job will appear in the list after the "Print" button is clicked.
 
@@ -378,10 +389,10 @@ to execute a print process in the command line. This process starts all the jobs
 
 
 Memory Limits
-=============
+-------------
 
-1. Queued Print
----------------
+*1. Queued Print*
+-----------------
 
 Print jobs can be resource intensive and may exceed your initially set php.ini memory limit. Therefore it is possible to increase the required memory limit manually. This is an advantage for users who are working with large print templates.
 Note: Never reduce the memory limit.
@@ -389,10 +400,11 @@ Note: Never reduce the memory limit.
 To increase the memory limits for the queued print, adjust `mapbender.print.queue.memory_limit` (string; default is 1G). Caution: This parameter does not allow 'null' as value.
 
 
-2. Direct Print
----------------
+*2. Direct Print*
+-----------------
 
 To increase the memory limit of the direct print, adjust `mapbender.print.memory_limit` (string or null; default is null) to your possible memory contigent.
 If the parameter is set to 'null', Mapbender print will look for your php.ini value.
 If you set the parameter to a value which is accepted by your php.ini-configuration file, Mapbender print uses this limit instead of the php.ini limit (possible values are e.g. 512M, 2G, 2048M, etc.)
 Use '-1' for unrestricted memory usage.
+


### PR DESCRIPTION
I made some changes to the German and English page of the PrintClient:
- changed the order of the texts to be more intuitive 
- corrected some minor errors
- added introduction/ overview about the PrintClient documentation, because it is pretty comprehensive
- reformatted headers, so sub-headers would have a smaller size than normal headers
