### PR TITLE
Update of Release History

### DIFF
--- a/de/release_history/3.0_versions.rst
+++ b/de/release_history/3.0_versions.rst
@@ -1,13 +1,83 @@
-.. _versions_de:
+.. _3.0_versions_de:
 
-Versionshistorie
-================
 
-`English Version of this document. <../en/versions.html>`_
+Versionshistorie für 3.0
+=========================
+
+`English Version of this document. <../../en/release_history/3.0_versions.html>`_
 
 Die Übersicht der Meilensteine finden Sie auf `Github <https://github.com/mapbender/mapbender/milestones>`_.
 
-.. _versions:
+
+
+Version 3.0.8.6
+---------------
+
+Release Datum: 15.09.2020
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3086
+
+
+Version 3.0.8.5
+---------------
+
+Release Datum: 05.02.2020
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3085
+
+
+Version 3.0.8.4
+---------------
+
+Release Datum: 04.09.2019
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3084
+
+
+Version 3.0.8.3
+---------------
+
+Release Datum: 05.07.2019
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3083
+
+
+Version 3.0.8.2.1
+-----------------
+
+Release Datum: 05.07.2019
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v30821
+
+
+Version 3.0.8.2
+---------------
+
+Release Datum: 03.07.2019
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3082
+
+
+Version 3.0.8.1
+---------------
+
+Release Datum: 14.05.2019
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3081
 
 
 Version 3.0.8
@@ -22,7 +92,7 @@ Release Datum: 12.04.2019
 
 **Hinweise zur Aktualisierung**
 
-https://github.com/mapbender/mapbender/blob/master/UPGRADING.md#308
+* https://github.com/mapbender/mapbender/blob/master/UPGRADING.md#308
 
 
 Version 3.0.7.7
@@ -100,7 +170,6 @@ Falls der Update Befehl fehlschlägt, z.B. mit der PostgreSQL Meldung ``SQLSTATE
                 SELECT x, id, length(x) FROM (
                   select value, id from  mb_core_keyword
                 ) AS t(x) order by length desc;
-
 
 
 Version 3.0.7.3
@@ -182,7 +251,6 @@ Verschiedenes:
 * Dateiname Präfix für Druckausgaben geändert.
 
 
-
 **Code-Verbesserungen:**
 
 * Update auf Symfony 2.8 (siehe PHP Voraussetzungen)
@@ -261,7 +329,6 @@ Release Datum: 27.07.2017
 * Regression: ScaleHint bei WMS Diensten korrigiert. Einige WMS Dienste mit einem Scale in den Capabilities konnten nicht in die Anwendung eingeladen werden. (#584)
 
 
-
 Version 3.0.6.2
 ---------------
 
@@ -293,7 +360,6 @@ Führen Sie nochmals den Befehl ``app/console doctrine:fixtures:load --fixtures=
 Führen Sie den Befehl ``app/console mapbender:upgrade:database`` aus, um den OL-ImagePath Parameter des Map-Controls anzupassen: Von ``bundles/mapbendercore/mapquery/lib/openlayers/img`` nach ``components/mapquery/lib/openlayers/img``. Das ist notwendig, falls Sie das POI-Element nutzen bzw. Mapbender mit dem poi-Parameter aufrufen und keine Sprechblase für den POI sehen. Beispiel: https://demo.mapbender.org/application/mapbender_user?poi[point]=366164%2C5623183&poi[scale]=25000&poi[label]=Please+take+a+look+at+this+POI%3A
 
 
-
 Version 3.0.6.1
 ---------------
 
@@ -311,7 +377,6 @@ Release Datum: 24.05.2017
 - Aktualisierung Startseite Dokumentation.
 - Kleine Styling Verbesserungen im Backend.
 - Kleine Säuberungen des Code.
-
 
 
 Version 3.0.6.0
@@ -512,10 +577,8 @@ Verzeichnis, in das YAML-basierende Anwendungen abgelegt werden können. Als Bei
                 ALTER TABLE mb_core_keyword ALTER value DROP DEFAULT;
 
 
-
-
-Milestone 3.0.5.3
------------------
+Version 3.0.5.3
+---------------
 
 Release Datum: 04.02.2016
 
@@ -589,11 +652,10 @@ Allgemeine Änderungen:
 
 - Das Sketch Tool funktioniert nicht korrekt und wird in Zukunft in das `Redlining Tool <functions/editing/redlining.html>`_ übernommen werden.
 - Karte weiterempfehlen funktioniert nicht für Facebook, Twitter und Google+.
-
     
     
-Milestone 3.0.5.2
------------------
+Version 3.0.5.2
+---------------
 
 Release Datum: 27.10.2015
 
@@ -645,10 +707,8 @@ Release Datum: 27.10.2015
                       login_delay_after_fail: 2 # Seconds
 
 
-
-
-Milestone 3.0.5.1
------------------
+Version 3.0.5.1
+---------------
 
 Release Datum: 26.08.2015
 
@@ -693,11 +753,9 @@ Release Datum: 26.08.2015
 - Kopieren von alten 3.0.4.1 Anwendungen kopiert nicht die anzuzeigenden Layersets der Map. Bitte speichern Sie vorher das Map und Overview-Element.
 - Regional Template entfernt
 
-
-
  
-Milestone 3.0.5.0
------------------
+Version 3.0.5.0
+---------------
 
 Release Datum: 01.07.2015
 
@@ -751,8 +809,8 @@ Release Datum: 01.07.2015
 * Beim Kopieren einer Anwendung von Mapbender 3.0.4.x muss in der Map/Overview der jeweilige Layerset neu gesetzt werden.
                     
 
-Milestone 3.0.4.1
------------------
+Version 3.0.4.1
+---------------
 
 Release Datum: 23-01-2015
 
@@ -778,8 +836,8 @@ Release Datum: 23-01-2015
 * https://github.com/mapbender/mapbender/milestones/3.0.4.1
  
 
-Milestone 3.0.4.0
------------------
+Version 3.0.4.0
+---------------
 
 Release Datum: 12-09-2014
 Übersicht der Änderungen finden Sie unter:  https://github.com/mapbender/mapbender-starter/blob/develop/CHANGELOG.md
@@ -796,8 +854,8 @@ Release Datum: 12-09-2014
 * spanische Übersetzung
  
 
-Milestone 3.0.3
-----------------
+Version 3.0.3
+-------------
 
 Release Datum: 17-03-2014
 Übersicht der Tickets finden Sie unter: https://github.com/mapbender/mapbender/issues?milestone=8
@@ -818,8 +876,8 @@ Release Datum: 17-03-2014
 * Funktion zur Validierung von WMS GetCapabilities Dokumenten
  
 
-Milestone 3.0.2
----------------
+Version 3.0.2
+-------------
 
 Release Datum: 27-11-2013
 Übersicht der Tickets finden Sie unter: https://github.com/mapbender/mapbender/issues?milestone=6
@@ -829,8 +887,8 @@ Release Datum: 27-11-2013
 * WMSLoader Erweiterung WMS über Link hinzufügen
  
 
-Milestone 3.0.1
----------------
+Version 3.0.1
+-------------
 
 Release Datum: 06-09-2013
 
@@ -843,8 +901,8 @@ Release Datum: 06-09-2013
 * Bug fixes
  
 
-Milestone 3.0.0.2
------------------
+Version 3.0.0.2
+---------------
 
 Bugfix-Release Datum: 19-07-2013
 
@@ -852,8 +910,8 @@ Bugfix-Release Datum: 19-07-2013
 
  
 
-Milestone 3.0.0.1
------------------
+Version 3.0.0.1
+---------------
 
 Bugfix-Release Datum: 07-06-2013
 
@@ -861,8 +919,8 @@ Bugfix-Release Datum: 07-06-2013
 
  
 
-Milestone 3.0.0.0
------------------
+Version 3.0.0.0
+---------------
 
 Release Datum: 29-05-2013
 

--- a/de/release_history/3.1_versions.rst
+++ b/de/release_history/3.1_versions.rst
@@ -1,0 +1,68 @@
+.. _3.1_versions_de:
+
+
+Versionshistorie für 3.1
+========================
+
+`English Version of this document. <../../en/release_history/3.1_versions.html>`_
+
+Die Übersicht der Meilensteine finden Sie auf `Github <https://github.com/mapbender/mapbender/milestones>`_.
+
+
+
+Version 3.1.0.10
+----------------
+
+Release Datum: 30.06.2020
+
+
+Version 3.1.0.9
+---------------
+
+Release Datum: 23.06.2020
+
+
+Version 3.1.0.8
+---------------
+
+Release Datum: 23.06.2020
+
+
+Version 3.1.0.7
+---------------
+
+Release Datum: 03.06.2020
+
+
+Version 3.1.0.6
+---------------
+
+Release Datum: 26.05.2020
+
+
+Version 3.1.0.5
+---------------
+
+Release Datum: 18.05.2020
+
+
+Version 3.1.0.4
+---------------
+
+Release Datum: 11.05.2020
+
+
+Version 3.1.0.3
+---------------
+
+Release Datum: 23.04.2020
+
+
+Version 3.1.0.2
+---------------
+
+Release Datum: 17.04.2020
+
+
+
+

--- a/de/release_history/3.2_versions.rst
+++ b/de/release_history/3.2_versions.rst
@@ -1,0 +1,62 @@
+.. _3.2_versions_de:
+
+
+Versionshistorie für 3.2
+========================
+
+`English Version of this document. <../../en/release_history/3.2_versions.html>`_
+
+Die Übersicht der Meilensteine finden Sie auf `Github <https://github.com/mapbender/mapbender/milestones>`_.
+
+
+
+Version 3.2.4
+-------------
+
+Release Datum: 04.03.2021
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v324
+
+
+Version 3.2.3
+-------------
+
+Release Datum: 21.12.2020
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v323
+
+
+Version 3.2.2
+-------------
+
+Release Datum: 02.11.2020
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v322
+
+
+Version 3.2.1
+-------------
+
+Release Datum: 06.08.2020
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v321
+
+
+Version 3.2.0
+-------------
+
+Release Datum: 29.07.2020
+
+**Verbesserungen und Bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v320
+
+

--- a/en/release_history/3.0_versions.rst
+++ b/en/release_history/3.0_versions.rst
@@ -1,11 +1,84 @@
-.. _versions:
+.. _3.0_versions:
 
-Version history
-===============
 
-`German Version of this document. <../de/versions.html>`_
+
+Version history of 3.0
+======================
+
+`German Version of this document. <../../de/release_history/3.0_versions.html>`_
 
 You find the milestones at: https://github.com/mapbender/mapbender/milestones
+
+
+Version 3.0.8.6
+---------------
+
+Release date: 15.09.2020
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3086
+
+
+Version 3.0.8.5
+---------------
+
+Release date: 05.02.2020
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3085
+
+
+Version 3.0.8.4
+---------------
+
+Release date: 04.09.2019
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3084
+
+
+Version 3.0.8.3
+---------------
+
+Release date: 05.07.2019
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3083
+
+
+Version 3.0.8.2.1
+-----------------
+
+Release date: 05.07.2019
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v30821
+
+
+Version 3.0.8.2
+---------------
+
+Release date: 03.07.2019
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3082
+
+
+Version 3.0.8.1
+---------------
+
+Release date: 14.05.2019
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v3081
+
 
 Version 3.0.8
 ---------------
@@ -49,7 +122,6 @@ Version 3.0.7.5
 
 Release date: 26.09.2018
 
-
 **Improvements and bugfixes:**
 
 * Find the description of the fixes in the repository links
@@ -67,7 +139,6 @@ Version 3.0.7.4
 ---------------
 
 Release date: 29.08.2018
-
 
 **Improvements and bugfixes:**
 
@@ -97,7 +168,6 @@ If this statement fails, for example with the PostgreSQL error ``SQLSTATE[22001]
                 SELECT x, id, length(x) FROM (
                   select value, id from  mb_core_keyword
                 ) AS t(x) order by length desc;
-
 
 
 Version 3.0.7.3
@@ -250,9 +320,7 @@ Version 3.0.7.2, 3.0.7.1 und 3.0.7.0
 
 Due to tagging-errors of the code in Github these versions were never officially released. It's not a good idea to re-tag the code, so we continued with Version 3.0.7.3.
 
-
   
-
 Version 3.0.6.3
 ---------------
 
@@ -262,7 +330,6 @@ Release date: 27.07.2017
 
 * Regression: Fixed coordinate order at requests to a WMS 1.3.0. Coordinate reference systems with reversed axis-orientation are supported by map, print and export. (#529)
 * Regression: Fixed ScaleHint for WMS services. Some WMS services that defined a Scale in their Capabilities couldn't be put into an application. (#584)
-
 
 
 Version 3.0.6.2
@@ -296,7 +363,6 @@ Execute again the command ``app/console doctrine:fixtures:load --fixtures=mapben
 Execute the command ``app/console mapbender:upgrade:database``, to update the OL-imagePath Parameter from ``bundles/mapbendercore/mapquery/lib/openlayers/img`` to ``components/mapquery/lib/openlayers/img``. This is necessary if you use the POI-Elements or call Mapbender with the poi-parameter and see no bubble-icon for the poi. Example: https://demo.mapbender.org/application/mapbender_user?poi[point]=366164%2C5623183&poi[scale]=25000&poi[label]=Please+take+a+look+at+this+POI%3A
 
 
-
 Version 3.0.6.1
 ---------------
 
@@ -314,7 +380,6 @@ Release date: 24.05.2017
 - Update landing-page of this documentation.
 - Some minor styling changes in backend.
 - Some cleanup.
-
 
 
 Version 3.0.6.0
@@ -519,9 +584,8 @@ Directory where YAML-based application definition are stored. As an example the 
                 ALTER TABLE mb_core_keyword ALTER value DROP DEFAULT;
 
 
-
-Milestone 3.0.5.3
------------------
+Version 3.0.5.3
+---------------
 
 Release date: 04.02.2016
 
@@ -595,9 +659,8 @@ General changes:
 - Share map doesn't work for Facebook, Twitter und Google+.
 
 
-
-Milestone 3.0.5.2
------------------
+Version 3.0.5.2
+---------------
 
 Release Datum: 27.10.2015
 
@@ -648,8 +711,8 @@ Release Datum: 27.10.2015
                       login_delay_after_fail: 2 # Seconds
 
 
-Milestone 3.0.5.1
------------------
+Version 3.0.5.1
+---------------
 
 Release Datum: 26.08.2015
 
@@ -695,8 +758,8 @@ Release Datum: 26.08.2015
 - Regional Template removed
 
 
-Milestone 3.0.5.0
------------------
+Version 3.0.5.0
+---------------
 
 Release Date: 01.07.2015
 
@@ -750,8 +813,8 @@ For details have a look at:  https://github.com/mapbender/mapbender-starter/blob
 * After copying an application from Mapbender 3.0.4.x you have to set the layerset in the map/overview element.
 
 
-Milestone 3.0.4.1
------------------
+Version 3.0.4.1
+---------------
 
 Release Datum: 23-01-2015
 
@@ -777,8 +840,8 @@ For details have a look at:  https://github.com/mapbender/mapbender-starter/blob
 * https://github.com/mapbender/mapbender/milestones/3.0.4.1
 
 
-Milestone 3.0.4.0
------------------
+Version 3.0.4.0
+---------------
 
 release date: 12-09-2014
 
@@ -796,8 +859,8 @@ For details have a look at https://github.com/mapbender/mapbender-starter/blob/d
 * spanish translation
 
 
-Milestone 3.0.3
----------------
+Version 3.0.3
+-------------
 
 release date: 17-03-2014
 
@@ -819,8 +882,8 @@ For details have a look at: https://github.com/mapbender/mapbender/issues?milest
 * Added function for validate WMS GetCapabilities documents
 
 
-Milestone 3.0.2
----------------
+Version 3.0.2
+-------------
 
 release date: 27-11-2013
 
@@ -831,8 +894,8 @@ For details have a look at https://github.com/mapbender/mapbender/issues?milesto
 * WMSLoader enhancement to load a WMS from a link
 
 
-Milestone 3.0.1
----------------
+Version 3.0.1
+-------------
 
 release date: 06-09-2013
 
@@ -845,26 +908,24 @@ For details have a look at https://github.com/mapbender/mapbender/issues?milesto
 * Bug fixes
 
 
-Milestone 3.0.0.2
------------------
+Version 3.0.0.2
+---------------
 
 Bugfix-Release Date: 19-07-2013
 
 For details have a look at: https://github.com/mapbender/mapbender/issues?milestone=4
 
 
-
-Milestone 3.0.0.1
------------------
+Version 3.0.0.1
+---------------
 
 Bugfix-Release Date: 07-06-2013
 
 For details have a look at: https://github.com/mapbender/mapbender/issues?milestone=3
 
 
-
-Milestone 3.0.0.0
------------------
+Version 3.0.0.0
+---------------
 
 release date: 29-05-2013
 

--- a/en/release_history/3.1_versions.rst
+++ b/en/release_history/3.1_versions.rst
@@ -1,0 +1,67 @@
+.. _3.1_versions:
+
+
+
+Version history of 3.1
+======================
+
+`German Version of this document. <../../de/release_history/3.1_versions.html>`_
+
+You find the milestones at: https://github.com/mapbender/mapbender/milestones
+
+
+
+Version 3.1.0.10
+----------------
+
+Release date: 30.06.2020
+
+
+Version 3.1.0.9
+---------------
+
+Release date: 23.06.2020
+
+
+Version 3.1.0.8
+---------------
+
+Release date: 23.06.2020
+
+
+Version 3.1.0.7
+---------------
+
+Release date: 03.06.2020
+
+
+Version 3.1.0.6
+---------------
+
+Release date: 26.05.2020
+
+
+Version 3.1.0.5
+---------------
+
+Release date: 18.05.2020
+
+
+Version 3.1.0.4
+---------------
+
+Release date: 11.05.2020
+
+
+Version 3.1.0.3
+---------------
+
+Release date: 23.04.2020
+
+
+Version 3.1.0.2
+---------------
+
+Release date: 17.04.2020
+
+

--- a/en/release_history/3.2_versions.rst
+++ b/en/release_history/3.2_versions.rst
@@ -1,0 +1,64 @@
+.. _3.2_versions:
+
+
+
+Version history of 3.2
+======================
+
+`German Version of this document. <../../de/release_history/3.2_versions.html>`_
+
+You find the milestones at: https://github.com/mapbender/mapbender/milestones
+
+
+
+
+Version 3.2.4
+-------------
+
+Release date: 04.03.2021
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v324
+
+
+Version 3.2.3
+-------------
+
+Release date: 21.12.2020
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v323
+
+
+Version 3.2.2
+-------------
+
+Release date: 02.11.2020
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v322
+
+
+Version 3.2.1
+-------------
+
+Release date: 06.08.2020
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v321
+
+
+Version 3.2.0
+-------------
+
+Release date: 29.07.2020
+
+**Improvements and bugfixes:**
+
+* https://github.com/mapbender/mapbender-starter/blob/master/CHANGELOG.md#v320
+
+


### PR DESCRIPTION
I updated the release history. I decided to split release versions into three categories: 3.0, 3.1 and 3.2. 
There were two reasons for that: 1. The number of releases made the sidepane and thus navigation in the documentation slowly confusing. 2. Some releases did not happen chronologically (e.g. releases of 3.1 happened sometimes before more 3.0 versions were brought out).

Linkages to changelog. were made whenever possible. Additionally, "milestones" were renamed to "version" to achieve consistency. 