### PR TITLE
Add information about root user in installation files

### DIFF
--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -117,6 +117,7 @@ Optional
 Der Root-Benutzerzugang ist der erste Mapbender-Benutzerzugang, er verfügt über alle Privilegien. Er muss mithilfe des Befehls:
 
 .. code-block:: bash
+
    app/console fom:user:resetroot
 
 zunächst initial angelegt werden. Im Anschluss werden benötigte Informationen abgefragt, die in der Datenbank hinterlegt werden. Überspringen des Dialogs mittels Enter führt zu den Standard-Werten bei der Benutzer-/Passworteingabe (root/root).
@@ -127,7 +128,7 @@ Weitere Informationen im Kapitel :ref:`installation_configuration_de`.
 
 Zur Nutzung der optionalen LDAP-Anbindung wird die PHP-LDAP-Extension benötigt:
 
-.. code-block:: text
+.. code-block:: bash
 
    sudo apt install php-ldap
 

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -112,6 +112,17 @@ Informationen zur Ersteinrichtung von Mapbender finden sich unter:  `Mapbender Q
 Optional
 --------
 
+**Root-Benutzer anlegen**
+
+Der Root-Benutzerzugang ist der erste Mapbender-Benutzerzugang, er verfügt über alle Privilegien. Er muss mithilfe des Befehls:
+
+.. code-block:: bash
+   app/console fom:user:resetroot
+
+zunächst initial angelegt werden. Im Anschluss werden benötigte Informationen abgefragt, die in der Datenbank hinterlegt werden. Überspringen des Dialogs mittels Enter führt zu den Standard-Werten bei der Benutzer-/Passworteingabe (root/root).
+
+Weitere Informationen im Kapitel :ref:`installation_configuration_de`.
+
 **LDAP**
 
 Zur Nutzung der optionalen LDAP-Anbindung wird die PHP-LDAP-Extension benötigt:

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -127,7 +127,7 @@ Weitere Informationen im Kapitel :ref:`installation_configuration_de`.
 
 Zur Nutzung der optionalen LDAP-Anbindung wird die PHP-LDAP-Extension benötigt:
 
-.. code-block:: bash
+.. code-block:: text
 
    sudo apt install php-ldap
 

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -169,6 +169,21 @@ Die Eingabeaufforderung öffnen. Zur Initialisierung der Datenbank folgende Befe
 Weitere Informationen zur Konfiguration: :ref:`installation_configuration_de`
 
 
+Standardbenutzer anlegen
+------------------------
+
+Der Root-Benutzerzugang ist der standardmäßige Mapbender-Benutzerzugang, er verfügt über alle Privilegien. Er muss mithilfe des Befehls:
+
+.. code-block:: text
+
+    cd c:\mapbender
+    php.exe app/console fom:user:resetroot
+
+zunächst initial angelegt werden. Im Anschluss werden benötigte Informationen abgefragt, die in der Datenbank hinterlegt werden. Überspringen des Dialogs mittels Enter führt zu den Standardwerten bei der Benutzer-/Passworteingabe (root/root).
+
+Weitere Informationen im Kapitel :ref:`installation_configuration_de`.
+
+
 Der erste Start
 ---------------
 

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -106,6 +106,17 @@ More information on proper configuration of Mapbender: `Mapbender Quickstart Doc
 Optional
 --------
 
+**Create root user**
+
+You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create it is:
+
+.. code-block:: bash
+   app/console fom:user:resetroot
+
+A dialogue form will then ask information about the user (name, password & optional e-mail) and will save it in the database. If nothing is inserted, the default values for username and password (root/root) apply.
+
+Find further information in :ref:`installation_configuration`.
+
 **LDAP**
 
 To use the optional LDAP-connection, following PHP-LDAP-extension is required:

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -110,7 +110,8 @@ Optional
 
 You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create one is:
 
-.. code-block:: text
+.. code-block:: bash
+   
    app/console fom:user:resetroot
 
 A dialogue form will then ask information about the user (name, password & optional e-mail) and will save it in the database. If nothing is inserted, the default values for username and password (root/root) apply.

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -108,9 +108,9 @@ Optional
 
 **Create root user**
 
-You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create it is:
+You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create one is:
 
-.. code-block:: bash
+.. code-block:: text
    app/console fom:user:resetroot
 
 A dialogue form will then ask information about the user (name, password & optional e-mail) and will save it in the database. If nothing is inserted, the default values for username and password (root/root) apply.

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -170,6 +170,21 @@ Open the windows shell and initialize the database connection with the following
 Following information: :ref:`installation_configuration`    
 
 
+Create root user
+-----------------------
+
+You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create it is:
+
+.. code-block:: text
+
+    cd c:\mapbender
+    php.exe app/console fom:user:resetroot
+
+A dialogue form will then ask information about the user (name, password & optional e-mail) and will save it in the database. If nothing is inserted, the default values for username and password (root/root) apply.
+
+Find further information in :ref:`installation_configuration`.
+
+
 First steps
 -----------
 

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -173,7 +173,7 @@ Following information: :ref:`installation_configuration`
 Create root user
 -----------------------
 
-You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create it is:
+You must create a default user before it is possible to log into the Mapbender backend. If there is no root user yet, the neccessary command to create one is:
 
 .. code-block:: text
 


### PR DESCRIPTION
Apparently, the installation files contain important information for new users.
As @astroidex pointed out, many questions arise how to log in successfully after a completed installation.
To prevent this and enhance installation ease, I added the information how to create(/reset) the root user in the according places.
See issue #175 for further details/comments.