### PR TITLE
Fix deprecated sitelink URL template

### DIFF
--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -111,7 +111,7 @@ Es kann ein Disclaimer mittels Sitelinks hinzugefügt werden. Dafür muss Folgen
 .. code-block:: yaml
 
     mapbender.sitelinks:
-      - link: https://mapbender.org/impressum-kontakt				# Link URL
+      - link: https://mapbender.org/impressum           			# Link URL
         text: Impressum & Kontakt									# Link Text
       - link: https://mapbender.org/datenschutz
         text: Datenschutz

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -116,10 +116,10 @@ A disclaimer can be added through the use of site links.
 .. code-block:: yaml
 
     mapbender.sitelinks:
-      - link: http://mapbender.org/en/about-contact				# Link URL
-        text: Imprint & Contact									# Link text
-      - link: http://mapbender.org/en/privacy-policy
-        text: Privacy-Policy
+      - link: https://mapbender.org/en/legal-notice/				# Link URL
+        text: Imprint & Contact									    # Link text
+      - link: https://mapbender.org/en/privacy-policy/
+        text: Privacy Policy
 
 Site links will be seperated by "|".
 


### PR DESCRIPTION
The current sitelink template in yaml.rst uses deprecated sitelinks to mapbender.org. This PR will fix the issue.