### PR TITLE
chore breakLine fix for upcoming documentation

### DIFF
--- a/de/functions/editing/digitizer/digitizer_configuration.rst
+++ b/de/functions/editing/digitizer/digitizer_configuration.rst
@@ -686,12 +686,12 @@ Textbereiche (type textArea)
                                                    title: Bestandsaufnahme Bemerkung # Beschriftung (optional)
 
 
-Trennlinien (type breakline)
+Trennlinien (type breakLine)
 ----------------------------
 
 .. code-block:: yaml
 
-                                                 - type: breakline      # fügt eine einfache Trennlinie ein
+                                                 - type: breakLine      # fügt eine einfache Trennlinie ein
 
 
 Checkboxen (type checkbox)

--- a/de/functions/editing/digitizer/digitizer_functionality.rst
+++ b/de/functions/editing/digitizer/digitizer_functionality.rst
@@ -26,7 +26,7 @@ Folgende Optionen stehen für den Aufbau von Formularen zur Verfügung:
 * Datumsauswahl
 * Dateiupload und Bildanzeige
 * Definition von Reitern
-* Definition von Trennlinien
+* Definition von Trennlinien (breakLine)
 * Definition von beschreibenden Texten zur Information
 * Definition von Hilfetexten
 * Pflichtfelder, Definition von regulären Ausdrücken für die Formatvorgabe bestimmter Feldinhalte

--- a/en/functions/editing/digitizer/digitizer_configuration.rst
+++ b/en/functions/editing/digitizer/digitizer_configuration.rst
@@ -692,12 +692,12 @@ Similar to the text field via type input (see above), text areas can be created 
                                                    title: Bestandsaufnahme Bemerkung # Label (optional)
 
 
-Breaklines (type breakline)
+Breaklines (type breakLine)
 ---------------------------
 
 .. code-block:: yaml
 
-                                                 - type: breakline                     # element type definition, will draw a line 
+                                                 - type: breakLine                     # element type definition, will draw a line 
 
 
 Checkboxes (type checkbox)

--- a/en/functions/editing/digitizer/digitizer_functionality.rst
+++ b/en/functions/editing/digitizer/digitizer_functionality.rst
@@ -26,7 +26,7 @@ The following option for the construction of the forms are available:
 * Datepicker
 * File upload and Image Display
 * Definition of tabs
-* Definition breaklines
+* Definition breakLines
 * Definition of Text 
 * Mandatory fields, regular expressions to valid the content are possible
 * Definition of help texts


### PR DESCRIPTION
Issue #234 wasn't fixed for new release branch yet and couldn't be transferred automatically due to restructuring of Digitizer pages. This PR changes the breakLine-type for the new documentation accordingly and therefore helps to keep the issue closed for a longer time.