### PR TITLE
Removal of deprecated doctrine:fixtures:load command from the installation pages

### DIFF
--- a/de/installation/installation_configuration.rst
+++ b/de/installation/installation_configuration.rst
@@ -99,7 +99,7 @@ Fügen Sie die Informationen zu den Koordinatensystemen über den folgenden Aufr
 
 .. code-block:: yaml
 
-    app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Epsg/ --append
+    app/console mapbender:database:init
 
 
 Importieren von Anwendungen aus application/app/config/applications
@@ -110,7 +110,7 @@ Sie können die Anwendungen, die in dem Ordner applications definiert sind, in d
 
 .. code-block:: yaml
 
-    app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+    bin/composer run reimport-example-apps
 
 
 Konfigurationsdateien

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -158,7 +158,7 @@ Initialisierung der Datenbank:
     app/console doctrine:database:create
     app/console doctrine:schema:create
     app/console mapbender:database:init -v
-    app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+    bin/composer run reimport-example-apps
 
 Root-Benutzer für Zugriff anlegen:
 

--- a/de/installation/installation_update.rst
+++ b/de/installation/installation_update.rst
@@ -55,7 +55,7 @@ Im Folgenden sind die einzelnen Schritte als Befehle aufgeführt.
  app/console doctrine:schema:update --force
 
  # Importieren Sie die Anwendungen aus der mapbender.yml Datei, um sich den neusten Stand der Entwicklungen anzuschauen
- app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+ bin/composer run reimport-example-apps
 
  app/console assets:install web --symlink --relative
  
@@ -96,7 +96,7 @@ Aktualisierungsbeispiel für Windows
  #            php -d extension=C:\ms4w\Apache\php\ext\php_pdo_pgsql.dll app/console doctrine:schema:update --dump-sql
   
  # Importieren Sie die Anwendungen aus der mapbender.yml Datei, um sich den neusten Stand der Entwicklungen anzuschauen
- php.exe app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+ php.exe bin/composer run reimport-example-apps
  php.exe app/console assets:install web
 
  # Löschen Sie den Cache und die Logdateien unter mapbender/app/cache und mapbender/app/logs

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -164,7 +164,7 @@ Die Eingabeaufforderung öffnen. Zur Initialisierung der Datenbank folgende Befe
     php.exe app/console doctrine:database:create
     php.exe app/console doctrine:schema:create
     php.exe app/console mapbender:database:init -v
-    php.exe app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+    php.exe bin/composer run reimport-example-apps
     
 
 Für den Zugriff auf die Datenbank muss der Standardbenutzer mit folgendem Befehl angelegt werden:

--- a/en/installation/installation_configuration.rst
+++ b/en/installation/installation_configuration.rst
@@ -102,12 +102,17 @@ Inserting Proj4 SRS parameters into a database can be done using the command:
 
 .. code-block:: yaml
 
-    app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Epsg/ --append
+    app/console mapbender:database:init
 
 Importing applications from application/app/config/applications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See chapter: :ref:`yaml_en`.
+
+It is possible to (re-)import applications from the applications folder into the database with the following command:
+
+.. code-block:: yaml
+
+    bin/composer run reimport-example-apps
 
 
 Configuration files

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -152,7 +152,7 @@ Initialisation of the database connection:
     app/console doctrine:database:create
     app/console doctrine:schema:create
     app/console mapbender:database:init -v
-    app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+    bin/composer run reimport-example-apps
     
 Create root user for access:
 

--- a/en/installation/installation_update.rst
+++ b/en/installation/installation_update.rst
@@ -95,7 +95,7 @@ Update Example for Windows
  #            php -d extension=C:\ms4w\Apache\php\ext\php_pdo_pgsql.dll app/console doctrine:schema:update --dump-sql
  
  # Import the applications from mapbender.yml to your database to get to know about the latest developments
- php.exe app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+ php.exe bin/composer run reimport-example-apps
  php.exe app/console assets:install web
 
  # Delete your cache and the logdateien at mapbender/app/cache und mapbender/app/logs

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -164,7 +164,7 @@ Open the windows shell and initialize the database connection with the following
     php.exe app/console doctrine:database:create
     php.exe app/console doctrine:schema:create
     php.exe app/console mapbender:database:init -v
-    php.exe app/console doctrine:fixtures:load --fixtures=./mapbender/src/Mapbender/CoreBundle/DataFixtures/ORM/Application/ --append
+    php.exe bin/composer run reimport-example-apps
 
 
 To gain database access, you have to create a default user via


### PR DESCRIPTION
There have been massive compatibility issues with Symfony and Fixtures versions, so we're switching to more useful commands.

Thus, this PR will remove the app/console doctrine:fixtures:load command from the installation/update files.

Since Mapbender 3.0.8.2, if you want to import applications from the applications folder into the database, it is possible to run:
bin/composer run reimport-example-apps

Since Mapbender 3.0.8.5 it is possible to fill in the EPSG codes via:
app/console mapbender:database:init