### PR TITLE
Replace deprecated 'anchor' with 'position' term 

### DIFF
--- a/de/functions/basic/zoom_bar.rst
+++ b/de/functions/basic/zoom_bar.rst
@@ -19,7 +19,7 @@ Konfiguration
 * **Target:** ID des Kartenelements, auf das sich das Element bezieht.
 * **Components:** Komponenten des Navigationswerkzeugs, standardmäßig wird alles selektiert; Auswahlmöglichkeiten: Rotation, zoom to max extent, Zurück zum Anfang, Zoom in/out und Zoom slider.
 * **Zurück zum Anfang** Zurücksetzen von Dienstzuständen. Der Standard ist false.
-* **Anchor:** Ausrichtung des Navigationswerkzeugs, Standard ist 'left-top' (oben-links); Auswahlmöglichkeiten: inline (zum Einbinden in der Sidepane), left-top (links-oben), left-bottom (links-unten), right-top (rechts-oben), right-bottom (rechts-unten)
+* **Position:** Ausrichtung des Navigationswerkzeugs, Standard ist 'left-top' (oben links); Auswahlmöglichkeiten: inline (zum Einbinden in der Sidepane), left-top (oben links), left-bottom (unten links), right-top (oben rechts), right-bottom (unten rechts)
 
 Komponenten des Navigationswerkzeugs:
 --------------------------------------

--- a/en/functions/basic/zoom_bar.rst
+++ b/en/functions/basic/zoom_bar.rst
@@ -20,7 +20,7 @@ Configuration
 * **Tooltip:** Text to use as tooltip.
 * **Components:** Components of the navigation toolbal (all selected by default). Options: Rotation, zoom to max extent, Back to start, Zoom in/out, Zoom slider
 * **Back to start:** Resets layer settings (default: false).
-* **Anchor:** Navigation toolbar alignment, default is 'left-top' (use inline e.g. in sidebar). Options: inline (for using the element in the sidepane), left-top, left-bottom, right-top, right-bottom
+* **Position:** Navigation toolbar alignment, default is 'left-top' (use inline e.g. in sidebar). Options: inline (for using the element in the sidepane), left-top, left-bottom, right-top, right-bottom
 
 
 Components of the Navigation Toolbar element:


### PR DESCRIPTION
The 'anchor' term has been replaced with 'position'. Adjusting this term for the  newer version of the documentation.