### PR TITLE
unify or fix note/hint messages

### DIFF
--- a/de/functions/editing/digitizer/digitizer_configuration.rst
+++ b/de/functions/editing/digitizer/digitizer_configuration.rst
@@ -739,7 +739,7 @@ Pflichtfelder
 
 Die Hinweise für ein Pflichtfeld erscheinen über dem jeweiligen Feldern. Bei einer fehlenden Angabe in einem definierten Pflichtfeld wird dieses rot umrandet und (wenn vorher definiert) erscheinen Hinweise. Das Objekt kann nicht gespeichert werden, wenn Pflichtangaben fehlen.
 
-.. note:: Hinweis: Bei der Nutzung von mehreren Reitern in dem Formular kann es sein, dass der Erfasser bei einem Pflichtfeld auf einem nicht sichtbaren Reiter eine Angabe falsch setzt und das Abspeichern daher nicht funktioniert. Hier erscheint keine Fehlermeldung außerhalb des Formulars. Der Erfasser muss die Angaben in dem Formular überprüfen (Kennzeichen: rote Umrandung/Sprechblase mit Hinweis), bevor diese korrekt abgespeichert werden können.
+.. note:: **Hinweis:** Bei der Nutzung von mehreren Reitern in dem Formular kann es sein, dass der Erfasser bei einem Pflichtfeld auf einem nicht sichtbaren Reiter eine Angabe falsch setzt und das Abspeichern daher nicht funktioniert. Hier erscheint keine Fehlermeldung außerhalb des Formulars. Der Erfasser muss die Angaben in dem Formular überprüfen (Kennzeichen: rote Umrandung/Sprechblase mit Hinweis), bevor diese korrekt abgespeichert werden können.
 
 .. code-block:: yaml
 

--- a/de/functions/search/search_router.rst
+++ b/de/functions/search/search_router.rst
@@ -12,7 +12,7 @@ Dieses Element erzeugt ein Suchformular mit Trefferausgabe. Das Formular und die
 Konfiguration
 =============
 
-.. note:: Die Suche greift auf Tabellen in einer Datenbank zu. Dafür muss die Datenbank in Mapbender bekannt gegeben werden. Informationen dazu finden sich unter :ref:`yaml_de`.
+.. note:: **Hinweis:** Die Suche greift auf Tabellen in einer Datenbank zu. Dafür muss die Datenbank in Mapbender bekannt gegeben werden. Informationen dazu finden sich unter :ref:`yaml_de`.
 
 Das Element kann entweder in der Sidepane oder als Button in der Toolbar integriert werden. Zu der Konfiguration des Buttons besuchen Sie die Dokumentationsseite unter :ref:`button_de`.
 
@@ -157,7 +157,7 @@ Die Auswahlmöglichkeiten werden im Bereich choices definiert. Dabei werden ein 
 * key - wird bei der Suchanfrage verwendet 
 * value - wird in der Auswahlbox angezeigt 
 
-..note: Ab Mapbender 3.2 sollte die Angabe in der Reihenfolge value: key erfolgen und die Typdefinition lautet type: Symfony\Component\Form\Extension\Core\Type\ChoiceType.
+.. note:: **Hinweis:** Ab Mapbender 3.2 sollte die Angabe in der Reihenfolge value: key erfolgen, die Typdefinition lautet type: Symfony\Component\Form\Extension\Core\Type\ChoiceType.
 
 * Typ choice; Beispiel für ein Feld mit Auswahlmöglichkeiten:
 

--- a/de/functions/share/view_manager.rst
+++ b/de/functions/share/view_manager.rst
@@ -6,7 +6,7 @@ Ansichtsverwaltung (View Manager)
 
 Das Element Ansichtsverwaltung erlaubt die Speicherung und Wiederverwendung von Kartenansichten. Folgende Kartenparameter sind hierin inbegriffen: Kartenposition, Maßstab, Koordinatenreferenzsystem, Drehung, Layer, Layerauswahl sowie Transparenz. Gesetzte Kartenansichten bleiben dabei auch nach Neuladen der Anwendung erhalten.
 
-.. note:: Hinweis: Die Ansichtsverwaltung wird bisher nur in der Sidepane unterstützt.
+.. note:: **Hinweis:** Die Ansichtsverwaltung wird bisher nur in der Sidepane unterstützt.
 
 .. image:: ../../../figures/de/view_manager_overview.png
      :scale: 80
@@ -21,7 +21,7 @@ Um eine neue Kartenansicht zu speichern, muss zunächst ein Titel für deren Re-
 
 In seiner einfachsten Form kann das Element zur Wiederverwendung von Kartenansichten verwendet werden. Diese Option ist immer vorhanden: Die zuvor gespeicherte Kartenansicht wird nach Klick auf den Abrufen-Button wiederhergestellt. Gespeicherte Ansichten können außerdem überschrieben oder gelöscht werden. Die Einträge in der Sidepane werden dabei entsprechend aktualisiert.
 
-.. note:: Hinweis: Aktuell unterstützt die Ansichtsverwaltung *nicht* folgende Konfigurationen:
+.. note:: **Hinweis:** Aktuell unterstützt die Ansichtsverwaltung *nicht* folgende Konfigurationen:
 
 * interaktiv hinzugefügte Instanzen (WMS laden)
 * interaktiv entfernte Instanzen (Ebenenbaum Kontextmenü)

--- a/de/installation/installation_configuration.rst
+++ b/de/installation/installation_configuration.rst
@@ -17,7 +17,7 @@ Im Folgenden werden die für die Mapbender-Installation aufgeführten Konfigurat
 
 Diese Schritte werden mit dem console-Hilfsprogramm des `Symfony <http://symfony.com/>`_ Frameworks durchgeführt, auf dem Mapbender aufbaut. Hier noch ein wichtiger Hinweis, bevor Sie fortfahren: 
 
-.. note:: Das console-Hilfsprogramm wird Dateien in die Verzeichnisse app/cache und app/logs schreiben. Für diese Operationen werden die Benutzerrechte des Benutzers benötigt, mit dem Sie angemeldet sind. Sie benötigen ebenfalls Benutzerrechte für das Verzeichnis app/db und die SQLite Datenbank.  Wenn Sie die Applikation in Ihrem Browser öffnen, wird der Server-PHP- Prozess versuchen, auf  diese Dateien zuzugreifen oder in die Verzeichnisse zu schreiben mit anderen Benutzerrechten. Stellen Sie sicher,  dass Sie den Verzeichnissen und Dateien Schreib- und Leserechte zugewiesen haben. 
+.. note:: **Hinweis:** Das console-Hilfsprogramm wird Dateien in die Verzeichnisse app/cache und app/logs schreiben. Für diese Operationen werden die Benutzerrechte des Benutzers benötigt, mit dem Sie angemeldet sind. Sie benötigen ebenfalls Benutzerrechte für das Verzeichnis app/db und die SQLite Datenbank.  Wenn Sie die Applikation in Ihrem Browser öffnen, wird der Server-PHP- Prozess versuchen, auf  diese Dateien zuzugreifen oder in die Verzeichnisse zu schreiben mit anderen Benutzerrechten. Stellen Sie sicher,  dass Sie den Verzeichnissen und Dateien Schreib- und Leserechte zugewiesen haben. 
 
 .. note:: **Wichtiger Hinweis:** Die folgenden app/console Schritte gehen davon aus, dass Sie sich oberhalb des app-Verzeichnisses befinden (für die git-Installation bedeutet das mapbender/application/ , andernfalls mapbender/).
 

--- a/en/development/element_generate.rst
+++ b/en/development/element_generate.rst
@@ -3,9 +3,9 @@
 How to create your own Element?
 ###############################
 
-*Note*: This guide is under complete restructuring. We will provide a new documentation in the Contributing Guite in our Git-Repository:
+.. note:: This guide is under complete restructuring. We will provide a new documentation in the Contributing Guite in our Git-Repository:
 
-`https://github.com/mapbender/mapbender-starter/blob/release/3.0.6/CONTRIBUTING.md <https://github.com/mapbender/mapbender-starter/blob/release/3.0.6/CONTRIBUTING.md>`_.
+`https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md>`_.
 
 
 Mapbender offers an app/console command to create different elements:
@@ -15,7 +15,7 @@ Mapbender offers an app/console command to create different elements:
 * elements for map-click events
 * elements for map-box events
 
-*Please note:* The new generated element contains only a skeleton and has to be modivied after generation.
+.. hint:: The new generated element contains only a skeleton and has to be modified after generation.
 
 The following example show the generation and modification of a map-click element.
 

--- a/en/functions/basic/map.rst
+++ b/en/functions/basic/map.rst
@@ -15,7 +15,7 @@ Configuration
      :scale: 80
 
 * **Title:** Title of the element. The title will be listed in "Layouts" and allows to distinguish between different buttons. It will be indicated if "Show label" is activated.
-* **Layersets:** Refers to a layerset. Note: Layersets have to be defined first and can then be referred to.
+* **Layersets:** Refers to a layerset. Layersets have to be defined first and can then be referred to.
 * **Tile size:** Size of the tiles of tiled WMS services.
 * **SRS:** Spatial reference system. Two ways of SRS definitions are supported: EPSG:CODE or EPSG:CODE|MY SRS TITLE.
 * **Max. Extent:** Maximal map extent, defined by BBOX parameters.

--- a/en/functions/editing/datamanager.rst
+++ b/en/functions/editing/datamanager.rst
@@ -20,7 +20,7 @@ Configuration example
 
 The definition of the Data Manager is done in YAML syntax in the textarea configuration at schemes. Here you define the database connection, the editable table, the attribute form.
 
-.. hint:: If errors occur in the database, fields or form, various error messages appear. Via the normal call and app.php comes a general error message. If you want to see the exact error message, you should call the page via app_dev.php. In this case, detailed error messages about the error behavior appear.
+.. hint:: If errors occur in the database, fields or form, various error messages appear. The productive call and app.php will give a general error message. If you want to see the exact error message, you should call the page via app_dev.php. In this case, detailed error messages about the error behavior will appear.
 
 Data Manager is a good solution to store simple contact information in Mapbender:
 

--- a/en/functions/editing/digitizer/digitizer_configuration.rst
+++ b/en/functions/editing/digitizer/digitizer_configuration.rst
@@ -751,7 +751,7 @@ Mandatory fields
 
 The notes for a mandatory field appear above the used fields. In the case of a missing entry in a defined mandatory field, this will be marked in red and (if defined) a speech bubble will appear. The object can not be saved if mandatory data is missing.
 
-.. note:: Note: When using multiple tabs in the form, the creator may set an entry incorrectly on a non-visible tab in a mandatory field, so the saving process does not work. No error message appears outside the form. The applicant has to check the information in the form (label: red border/speech bubble with reference) before it can be stored correctly.
+.. note:: When using multiple tabs in the form, the creator may set an entry incorrectly on a non-visible tab in a mandatory field, so the saving process does not work. No error message appears outside the form. The applicant has to check the information in the form (label: red border/speech bubble with reference) before it can be stored correctly.
 
 .. code-block:: yaml
 

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -300,7 +300,7 @@ Define text fields in the print template for every information you would like to
 *3. Call feature print from FeatureInfo*
 ----------------------------------------
 
-Note: FeatureInfo is the information output from a OGC WMS service. It offers information for features at a click position.
+.. note:: FeatureInfo is the information output from a OGC WMS service. It offers information for features at a click position.
 
 When you configure a WMS, you can generate a link with the following reference that will trigger the print with feature information.
 
@@ -335,7 +335,7 @@ To activate the functionality, add the following parameter to the digitizer conf
 
 With click on the print button the print dialog opens and offers the print templates that are defined for the feature type.
 
-Note: The flexibility to move the print frame won‘t stop you from choosing a region that does not contain the feature that was selected. In this case, the feature information does not match to the features that are displayed.
+.. note:: The flexibility to move the print frame won‘t stop you from choosing a region that does not contain the feature that was selected. In this case, the feature information does not match to the features that are displayed.
 
 
 Queued Print
@@ -375,7 +375,7 @@ After the setup, the queued print can be controlled with several bash commands, 
     mapbender:print:queue:rerun
     mapbender:print:runJob
 
-Note: To run the commands, open a terminal and head to the Mapbender application directory. Then, execute a command like this: 'app/console mapbender:print:queue:clean'. Detailed information on the commands:  `app/console commands <../../customization/commands.html>`_.
+.. note:: To run the commands, open a terminal and head to the Mapbender application directory. Then, execute a command like this: 'app/console mapbender:print:queue:clean'. Detailed information on the commands:  `app/console commands <../../customization/commands.html>`_.
 
 
 *Queued print: Usage*
@@ -402,7 +402,7 @@ Memory Limits
 --------------
 
 Print jobs can be resource intensive and may exceed your initially set php.ini memory limit. Therefore it is possible to increase the required memory limit manually. This is an advantage for users who are working with large print templates.
-Note: Never reduce the memory limit.
+.. note:: Never reduce the memory limit.
 
 To increase the memory limits for the queued print, adjust `mapbender.print.queue.memory_limit` (string; default is 1G). Caution: This parameter does not allow 'null' as value.
 

--- a/en/functions/search/search_router.rst
+++ b/en/functions/search/search_router.rst
@@ -155,7 +155,7 @@ You have to define the choices for the selectbox. You define a value and a key.
 * key - will be send in the search query
 * value - is show as text in selectbox
 
-..note: Please note that from Mapbender 3.2 you should use the value: key definition and type: Symfony\Component\Form\Extension\Core\Type\ChoiceType
+.. note:: From Mapbender 3.2 on onwards, you should use the value: key definition and type: Symfony\Component\Form\Extension\Core\Type\ChoiceType
 
 * Type choice; example with different selection options via dropdown:
 

--- a/en/functions/share/view_manager.rst
+++ b/en/functions/share/view_manager.rst
@@ -5,7 +5,7 @@ View Manager
 
 This element View Manager stores and reapplies map states. These contain the following map parameters: center, scale, srs, rotation, layer/source, layerset selection, source opacities. Saved states are always reapplied on top of the current configuration. This means that changed application configurations will remain in effect after reload of the map state.
 
-.. note:: Note: Thus far the View Manager can only be implemented in the Sidepane.
+.. note:: Thus far the View Manager can only be implemented in the Sidepane.
 
 .. image:: ../../../figures/view_manager_overview.png
      :scale: 80
@@ -20,7 +20,7 @@ Each state must be given a title for reidentification. For saving the current ma
 
 The most basic interaction (always available) is re-applying the map state stored in the entry. This option is always on: The saved map state will be reapplied as soon as "Apply" is hit on the selected map state in list view. Moreover, entries may offer a "Replace" interaction. This will overwrite the map state stored in the entry, and will also update the title, using the global title input field. Also, entries may offer a "Delete" interaction (with an extra confirmation step).
 
-.. note:: Note: The View Manager does *not* store or reapply the following configurations:
+.. note:: The View Manager does *not* store or reapply the following configurations:
 
 * any interactively added sources (via WmsLoader)
 * any interactively removed layers (via Layertree context menu)

--- a/en/installation/installation_configuration.rst
+++ b/en/installation/installation_configuration.rst
@@ -19,7 +19,7 @@ All that can be done using the console utility provided by `Symfony <http://symf
 
 .. note:: The console utility will write files in the app/cache and app/logs directories. These operations are made using the user permissions of whatever user you're logged in with. This is also true for the app/db directory and the SQLite database within. When you open the application from within the browser, the server PHP process will try to access/write all these files with other permissions. So make sure you give the PHP process write access to these files. See last step below.
 
-.. note:: **Notice:** The following steps assume that you are in the directory above the app directory (notice that for git installation that means mapbender/application/, else mapbender/).
+.. note:: **Important:** The following steps assume that you are in the directory above the app directory (notice that for git installation that means mapbender/application/, else mapbender/).
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Quick fix for info boxes:

- Fixes syntax errors for note boxes
- Unifies german "Hinweis" translation
- Removes unnecessary English duplicate term (Note - Note: or Hint - Hint:)
- Changes an URL (Reference to master instead of 3.0.6)