### PR TITLE
Refer to existing 404.rst

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -1,14 +1,15 @@
-.. _page_not_found:
+.. _page_not_found: :orphan:
+    
 
-Page not found / Seite nicht gefunden (HTTP 404)
-################################################
+Page not found / Seite nicht gefunden (404 Not Found)
+#####################################################
 
 
 **Page not found**
 
 Ooops, the page you were looking for was moved or doesn't exist.
 
-Let's get back to the `Main Page <http://doc.mapbender.org/>`_.
+Let's get back to the `Main Page <https://doc.mapbender.org/>`_.
 
 -----
 
@@ -16,7 +17,7 @@ Let's get back to the `Main Page <http://doc.mapbender.org/>`_.
 
 Hoppla, die Seite, die Sie aufrufen wollten, wurde entweder verschoben oder existiert gar nicht.
 
-Lassen Sie uns zur `Hauptseite <http://doc.mapbender.org/>`_ zurückgehen.
+Lassen Sie uns zur `Hauptseite <https://doc.mapbender.org/>`_ zurückgehen.
 
 
      

--- a/conf.py
+++ b/conf.py
@@ -19,11 +19,16 @@ needs_sphinx = '1.8'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    'notfound.extension',
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinxcontrib.phpdomain'
 ]
+
+# -- notfound.extension
+notfound_template = "404.html"
+notfound_no_urls_prefix = None
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
I noticed that Mapbender's documentation is throwing a blank Apache 404 error, so I sought for a better solution:

- We already have a 404.rst in the repo that is just not being called correctly.
- There is a Sphinx extension called notfound-page that helps with a clean 404 page and allows custom 404.rst.

--> I implemented the extension in our conf.py and linked it with a slightly updated 404.rst.

When reviewing, please check the [extension's documentation](https://sphinx-notfound-page.readthedocs.io/en/latest/index.html) and look for possible adjustments I might have overlooked.