### PR TITLE
Add information about WMS maxsize to printclient.rst

### DIFF
--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -355,7 +355,7 @@ Bemerkung: Die Flexibilität, den Druckrahmen zu verschieben, hindert den Anwend
 Warteschleifendruck
 -------------------
 
-Der Warteschleifendruck ist ein neues Druckfeature in Mapbender, welches einen erweiterten Hintergrunddruck erlaubt. Dieses experimentelle Feature ist seit Mapbender 3.0.8 implementiert. Es ist standardmäßig nicht aktiviert, da bei komplexeren Systemen Probleme mit der Cache-Speicher-Regeneration auftreten können. Sobald aktiviert, kann das Feature entweder händisch über die Kommandozeile angestoßen oder über einen Cronjob automatisiert werden. Der Warteschleifendruck hilft dabei, ressourcenintensive Druckjobs mit langen Ausführungszeiten zu verbessern, indem diese in eine Warteschleife, die im Hintergrund abgearbeitet wird, ausgelagert werden. Währenddessen können Sie mit Mapbender anderweitig weiterarbeiten.
+Der Warteschleifendruck ist ein Druckfeature in Mapbender, welches einen erweiterten Hintergrunddruck erlaubt. Dieses experimentelle Feature ist seit Mapbender 3.0.8 implementiert. Es ist standardmäßig nicht aktiviert, da bei komplexeren Systemen Probleme mit der Cache-Speicher-Regeneration auftreten können. Sobald aktiviert, kann das Feature entweder händisch über die Kommandozeile angestoßen oder über einen Cronjob automatisiert werden. Der Warteschleifendruck hilft dabei, ressourcenintensive Druckjobs mit langen Ausführungszeiten zu verbessern, indem diese in eine Warteschleife, die im Hintergrund abgearbeitet wird, ausgelagert werden. Währenddessen können Sie mit Mapbender anderweitig weiterarbeiten.
 
 
 *Warteschleifendruck: Konfiguration*
@@ -413,15 +413,29 @@ Speicherbegrenzungen
 *Warteschleifendruck*
 ---------------------
 
-Da der Druck möglicherweise speicherintensiver sein kann als anfangs in Ihren PHP-Einstellungen festgelegt, kann der benötigte Speicher durch manuelle Konfiguration erhöht werden. Dies ist für Anwender, die mit größeren Ausdrucken arbeiten möchten, besonders von Vorteil.
-Bemerkung: Die Speicherbegrenzung sollte nicht reduziert werden.
-
+Da der Warteschleifendruck möglicherweise speicherintensiver sein kann als anfangs in Ihren PHP-Einstellungen festgelegt, kann der benötigte Speicher durch manuelle Konfiguration erhöht werden. Dies ist für Anwender, die mit größeren Ausdrucken arbeiten möchten, besonders von Vorteil.
 Der Parameter `mapbender.print.queue.memory_limit` (string; Standard: 1G) muss angepasst werden, um die Speicherbegrenzung speziell für den Warteschleifendruck zu erhöhen. Vorsicht: Dieser Parameter erlaubt keine "null"-Werte.
+
+.. note:: Bemerkung: Reduzieren Sie die Speicherbegrenzung nicht.
 
 
 *Direktdruck*
 -------------
 
-Über den Parameter `mapbender.print.memory_limit` (string or null; Standard: null) kann das Speicherlimit angepasst werden (mögliche Werte sind bspw. 512M, 2G, 2048M, etc.).
+Über den Parameter `mapbender.print.memory_limit` (string or null; Standard: null) kann das Speicherlimit auch für den Direktdruck angepasst werden (mögliche Werte sind bspw. 512M, 2G, 2048M, etc.).
 Ist der Parameter "null" eingestellt, passt sich der Druck an die vorgegebene php.ini-Begrenzung an, der Wert "-1" steht für unbegrenzte Speichernutzung.
 
+
+WMS-Kachelgröße begrenzen
+-------------------------
+
+Sofern der Druck einen WMS-Dienst nicht erfolgreich in die PDF-Datei exportieren sollte, muss in der parameters.yml-Datei eine Ergänzung vorgenommen werden.
+Das hat damit zu tun, dass unter bestimmten Umständen die angeforderte Pixelausdehnung für den WMS zu groß ist, sodass der Dienst keine Bilder mehr liefert.
+
+.. code-block:: yaml
+
+    mapbender.imaageexport.renderer.wms.max_getmap_size: 8192
+
+
+Durch diese Begrenzung werden die größtmöglichen WIDTH=- und HEIGHT=-Werte für die Exportanfrage festgelegt. Im GetCapabilities-Request des jeweiligen Dienstes wird die maximale Auflösung unter ``MaxWidth`` bzw. ``MaxHeight`` definiert, sodass der getCapabilities-Request das Limit bereits vorgibt - bei `8192` handelt es sich um den Standardwert, der eventuell weiter angepasst werden muss.
+Die oben genannten Parameter können auch unabhängig voneinander definiert werden. Verwenden Sie ``mapbender.imaageexport.renderer.wms.max_getmap_size.x`` für den **WIDTH=**- und ``mapbender.imaageexport.renderer.wms.max_getmap_size.y`` für den **HEIGHT=**-Parameter.

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -402,6 +402,7 @@ Memory Limits
 --------------
 
 Print jobs can be resource intensive and may exceed your initially set php.ini memory limit. Therefore it is possible to increase the required memory limit manually. This is an advantage for users who are working with large print templates.
+
 .. note:: Never reduce the memory limit.
 
 To increase the memory limits for the queued print, adjust `mapbender.print.queue.memory_limit` (string; default is 1G). Caution: This parameter does not allow 'null' as value.
@@ -415,3 +416,17 @@ If the parameter is set to 'null', Mapbender print will look for your php.ini va
 If you set the parameter to a value which is accepted by your php.ini-configuration file, Mapbender print uses this limit instead of the php.ini limit (possible values are e.g. 512M, 2G, 2048M, etc.)
 Use '-1' for unrestricted memory usage.
 
+
+Set a WMS Tile Size Limit
+-------------------------
+
+If the printing process fails to export a WMS service into the PDF file, the following amendment needs to be made in the parameters.yml file.
+This is because, under certain circumstances, the requested pixel size for the WMS is too large, resulting in the service no longer delivering images.
+
+.. code-block:: yaml
+
+    mapbender.imaageexport.renderer.wms.max_getmap_size: 8192
+
+    
+These limitations set the maximum possible WIDTH= and HEIGHT= values for the export request. In the GetCapabilities request of the respective service, the maximum resolution is defined under `MaxWidth` and `MaxHeight`, which means that the getCapabilities request already sets the limit - `8192` is the default value, which may need to be further adjusted.
+The mentioned parameters can also be defined independently of each other: Use ``mapbender.imageexport.renderer.wms.max_getmap_size.x`` for the **WIDTH=** parameter and ``mapbender.imageexport.renderer.wms.max_getmap_size.y`` for the **HEIGHT=** parameter.


### PR DESCRIPTION
As requested in #369 :

The maxsize parameters (adjusted copypaste from FAQ pages) have been added to printclient.rst.