### PR TITLE
Remove content from documentation_howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ The sources are [on Github](https://github.com/mapbender/mapbender-documentation
 
 The website code is generated using [Sphinx](http://sphinx-doc.org/), therefore the documentation source is written in [Restructured Text](http://sphinx-doc.org/rest.html).
 
-You can find instructions on how the documentation is structured in chapter [How to write Mapbender Documentation?](http://doc.mapbender.org/en/book/development/documentation_howto.html) or directly [in this Git-Repository](https://github.com/mapbender/mapbender-documentation/blob/master/en/documentation_howto.rst).
-
-
 To build the website locally, you need to install Sphinx. Install it in Debian-based distributions via
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This is the Mapbender documentation repository.
 
-You can find the compiled pages of [the latest released version](https://github.com/mapbender/mapbender-documentation/releases) at [https://doc.mapbender.org/](https://doc.mapbender.org/). Other versions of the documentation are also available at [https://docs.mapbender.org/](https://docs.mapbender.org/current/#other-versions-of-this-documentation).
+You can find the compiled pages of [the latest released version](https://github.com/mapbender/mapbender-documentation/releases) at [https://doc.mapbender.org/](https://doc.mapbender.org/). Other versions of the documentation are also available at [https://docs.mapbender.org/](https://docs.mapbender.org/current/##older-versions).
 
 The sources are [on Github](https://github.com/mapbender/mapbender-documentation).
 
 The website code is generated using [Sphinx](http://sphinx-doc.org/), therefore the documentation source is written in [Restructured Text](http://sphinx-doc.org/rest.html).
 
-To build the website locally, you need to install Sphinx. Install it in Debian-based distributions via
+To build the website locally, you need to install Sphinx first. Install it in Debian-based distributions via
 
 ```bash
 sudo apt-get install sphinx-common python3-sphinx
@@ -21,13 +21,12 @@ sudo pip install sphinx-notfound-page
 You can then build the documentation by running:
 
 ```bash
-$ make
+make
 ```
 
-Example
+## How to build the documentation
 
 ```bash
-
 cd /data
 git clone git@github.com:mapbender/mapbender-documentation
 cd mapbender-documentation
@@ -39,11 +38,57 @@ ln -s /data/mapbender-documentation/_build/ /var/www/html/mb-doc
 
 http://localhost/mb-doc/
 
-If you want rebuild the documentation delete the old version before
+If you want rebuild the documentation, delete the old version before
 rm -rf _build
 ```
 
-To participate in the documentation, create a fork and submit a pull request with your changes.
+## How to participate in the documentation
 
+To participate in the documentation, create a fork and submit a pull request with your changes. In your fork, write new content, e.g.:
+
+```bash
+  cd /mapbender-documentation/en/functions/basic # Let's assume that you want to create a docs page that is part of the Mapbender CoreBundle. Switch to the folder where your file should be located.
+  cp overview.rst basic/add_wms.rst  # Create a rst-file. E.g., copy the overview.rst as template for your add_wms.rst documentation file.
+  # Write the documentation: keep it short and simple. Use the structure of the document.
+  sphinx-build . _build -A version=3.3.0 # Build the documentation locally to see how your documentation looks like. Adjust the version number (if necessary).
+  ln -s /data/mapbender-documentation/_build/ /var/www/html/mb-doc # Create a symlink from your Sphinx build folder to your Apache web server to test the documentation locally.
+```
+
+Now, take a look at the documentation page in your browser. Is everything ok? Are any changes needed? If not, you can create a pull request to add your reviewed changes into the documentation.
+
+## Rules
+
+Below you'll find some basic conventions about documentation writing.
+
+### Images (figures)
+
+Images for the documentation are located at mapbender-documentation/figures
+
+* Create images with size 800 x 600px
+* Have a look at quickstart.rst to learn about image referring
+* For elements, use elementname.png and elementname_configuration.png as name. If you also provide german image files, please keep the names and create two more images in the de folder.
+
+### Languages
+
+The two fully supported languages (i.e.: en - english, de - german) should have the same file structure, that is:
+
+```bash
+  /mapbender-documentation
+    index.rst          # refers to the different languages
+    /figures           # images that are included in the documentation
+    /de                # German file locations
+      ...
+    /en                # English file locations
+      index.rst        # refers to TheBook, Developer's Book & the Bundle Documentation
+      bundles.rst      # lists the chapters of this category - refers to rst files
+      development.rst  # lists the chapters of this category - refers to rst files
+      /architecture
+      /development
+          ....
+      /functions
+          /backend
+          /basic
+          ....
+```
 
 Have fun!

--- a/en/documentation_howto.rst
+++ b/en/documentation_howto.rst
@@ -2,29 +2,25 @@
 
 How to write Mapbender Documentation?
 #####################################
-This documentation is build and deployed from the mapbender-documentation repository on Github.
+This documentation is built and deployed from the mapbender-documentation repository on Github.
 
 Please take a look at the documentation files in this repository:
 
 https://github.com/mapbender/mapbender-documentation/
-
-.. code-block:: bash
-
-   git clone git@github.com:mapbender/mapbender-documentation
 
 
 How to build the documentation via Sphinx?
 ******************************************
 We generate the website code from the rst-files using Sphinx.
 
-To build the website locally, you need to install Sphinx first. Read more in the README.md of the repository:
+To build the website locally, you need to install Sphinx first. Find more information in the README.md file:
 
 https://github.com/mapbender/mapbender-documentation/blob/master/README.md
 
 
 Example for element documentation
 *********************************
-Let's assume that you are a developer and just added a new element to Mapbender code base. In this example, your element is called AddWMS and is part of the Mapbender CoreBundle.
+Let's assume that you are a developer and just added a new element to the Mapbender code base. In this example, your element is called AddWMS and is part of the Mapbender CoreBundle.
 
 **Now it is time to write the documentation!**
 
@@ -32,34 +28,32 @@ Here are the steps you have to do:
 
 .. code-block:: bash
 
-  # get the documentation files from github
+  # Get the documentation files from GitHub:
   cd /data
   git clone git@github.com:mapbender/mapbender-documentation
   cd /mapbender-documentation/en/functions/basic
 
-  # create a rst-file. Use the overview.rst as template for element documentation!
+  # Create a rst-file. E.g., use the overview.rst as template for element documentation:
   cp overview.rst basic/add_wms.rst
 
-  # write the documentation. You find information how and what to write in the documentation in template_element.rst
+  # Write the documentation: keep it short and simple.
 
-  # keep it short and simple
-
-  # build the documentation locally to see how your documentation looks like
+  # Build the documentation locally to see how your documentation looks like. Adjust the version number (if necessary).
   cd /data/mapbender-documentation/
   rm -Rf _build
   sphinx-build . _build -A version=3.3.0
 
-  # have a look at the documentation in your browser (example location). Is everything ok? Are any changes needed?
+  # Have a look at the documentation in your browser (example location). Is everything ok? Are any changes needed?
   ln -s /data/mapbender-documentation/_build/ /var/www/html/mb-doc
   http://localhost/mb-doc/
 
-  # Next, add, commit and push your new file to the mapbender-documentation repository
+  # Next, add, commit and push your new file to the mapbender-documentation repository:
   git checkout -b feature/add_wms
   git add en/functions/basic/add_wms.rst
   git commit -m 'new documentation for element <element_name>'
   git push --set-upstream origin feature/add_wms
 
-  # get the actual files from the mapbender-documentation repository
+  # To get the actual files from the mapbender-documentation repository, run
   git checkout master
   git pull
 
@@ -70,13 +64,13 @@ Images for the documentation are located at:
 
 * mapbender-documentation/figures
 * create images with size 800 x 600px (you can resize your browser window, e.g. with web developer to this size)
-* have a look at quickstart.rst about how to refer to an image
+* have a look at quickstart.rst to learn about image referring
 * for elements, use elementname.png and elementname_configuration.png as name. If you also provide german image files, please keep the names and create two more images in the de folder.
 
 
 Languages
 *********
-All fully supported languages (i.e.: en - english, de - german) should have the same file structure.
+At last, all fully supported languages (i.e.: en - english, de - german) should have the same file structure.
 
 .. code-block:: yaml
 

--- a/en/documentation_howto.rst
+++ b/en/documentation_howto.rst
@@ -2,21 +2,9 @@
 
 How to write Mapbender Documentation?
 #####################################
+This documentation is build and deployed from the mapbender-documentation repository on Github.
 
-Mapbender Documentation website
-*******************************
-
-You find the Mapbender Documentation at:
-
-https://doc.mapbender.org
-
-The Documentation is build from the mapbender-documentation repository at Github. This repository is used to build and deploy the https://doc.mapbender.org website. The website code is generated using Sphinx, therefore the documentation source is written in Restructured Text.
-
-
-Edit documentation at Git Repository mapbender-documentation
-************************************************************
-
-The documentation files are located at the git repository:
+Please take a look at the documentation files in this repository:
 
 https://github.com/mapbender/mapbender-documentation/
 
@@ -24,11 +12,71 @@ https://github.com/mapbender/mapbender-documentation/
 
    git clone git@github.com:mapbender/mapbender-documentation
 
-Structure of the documentation
-********************************************
-We want to provide documentation in different languages. The language we want to support first is english. So every document should be build up in english first.
 
-Every language (en - english, de - german) has the same file structure.
+How to build the documentation via Sphinx?
+******************************************
+We generate the website code from the rst-files using Sphinx.
+
+To build the website locally, you need to install Sphinx first. Read more in the README.md of the repository:
+
+https://github.com/mapbender/mapbender-documentation/blob/master/README.md
+
+
+Example for element documentation
+*********************************
+Let's assume that you are a developer and just added a new element to Mapbender code base. In this example, your element is called AddWMS and is part of the Mapbender CoreBundle.
+
+**Now it is time to write the documentation!**
+
+Here are the steps you have to do:
+
+.. code-block:: bash
+
+  # get the documentation files from github
+  cd /data
+  git clone git@github.com:mapbender/mapbender-documentation
+  cd /mapbender-documentation/en/functions/basic
+
+  # create a rst-file. Use the overview.rst as template for element documentation!
+  cp overview.rst basic/add_wms.rst
+
+  # write the documentation. You find information how and what to write in the documentation in template_element.rst
+
+  # keep it short and simple
+
+  # build the documentation locally to see how your documentation looks like
+  cd /data/mapbender-documentation/
+  rm -Rf _build
+  sphinx-build . _build -A version=3.3.0
+
+  # have a look at the documentation in your browser (example location). Is everything ok? Are any changes needed?
+  ln -s /data/mapbender-documentation/_build/ /var/www/html/mb-doc
+  http://localhost/mb-doc/
+
+  # Next, add, commit and push your new file to the mapbender-documentation repository
+  git checkout -b feature/add_wms
+  git add en/functions/basic/add_wms.rst
+  git commit -m 'new documentation for element <element_name>'
+  git push --set-upstream origin feature/add_wms
+
+  # get the actual files from the mapbender-documentation repository
+  git checkout master
+  git pull
+
+
+Images (figures)
+****************
+Images for the documentation are located at:
+
+* mapbender-documentation/figures
+* create images with size 800 x 600px (you can resize your browser window, e.g. with web developer to this size)
+* have a look at quickstart.rst about how to refer to an image
+* for elements, use elementname.png and elementname_configuration.png as name. If you also provide german image files, please keep the names and create two more images in the de folder.
+
+
+Languages
+*********
+All fully supported languages (i.e.: en - english, de - german) should have the same file structure.
 
 .. code-block:: yaml
 
@@ -48,94 +96,3 @@ Every language (en - english, de - german) has the same file structure.
           /backend
           /basic
           ....
-
-
-How to build the documentation via Sphinx?
-******************************************
-We generate the website code from the rst-files using Sphinx.
-
-To build the website locally, you need to install Sphinx. Read more in the README.md
-
-https://github.com/mapbender/mapbender-documentation/blob/master/README.md
-
-
-How to write documentation?
-***************************
-We write documentation for elements, entities, services.
-
-
-Images (figures)
-****************
-Images for the documentation are **all** located at
-
-* mapbender-documentation/figures
-* create images with size 800 x 600px (you can resize your browser window e.g. with web developer to this size)
-* have a look at quickstart.rst about how to refer to an image
-* for elements use elementname.png and elementname_configuration.png as name. If you provide also image for de please keep the names and create 2 more image in the de folder
-
-
-Quickstart
-**********
-
-The Mapbender Quickstart is a tutorial to get to know Mapbender. It is used on OSGeoLive too http://live.osgeo.org.
-
-If you want to add a new lesson to the Quickstart:
- * add the subject of your lesson at the beginning of the document (This Quick Start describes how to: ...)
- * add the new lesson to the document and provide a screenshot if this makes sense
- * images are stored in the ../../../figures-directory
-
-
-Example for element documentation
-*********************************
-You have to write a new element documentation when a new element with new functionality is added to Mapbender.
-
-In this example we assume, that you are a developer and just added a new element to Mapbender code base. We assume your element is called AddWMS and is part of the Mapbender CoreBundle.
-
-**Now it is time to write the documentation!**
-
-Here are the steps you have to do:
-
-.. code-block:: bash
-
-  # get the documentation files from github
-  cd /data
-  git clone git@github.com:mapbender/mapbender-documentation
-  cd /mapbender-documentation/en/functions/basic
-
-  # create a rst-file. Use the over.rst as template for element documentation!
-  cp overview.rst basic/add_wms.rst
-
-  # write the documentation. You find information how and what to write in the documentation in template_element.rst
-
-  # keep it simple
-
-  # build the the documentation locally to see how your documentation looks like
-  cd /data/mapbender-documentation/
-  rm -Rf _build
-  sphinx-build . _build -A version=3.3.0
-
-  # have a look at the documentation in your browser (example location). Is everything ok? Any changes needed?
-  ln -s /data/mapbender-documentation/_build/ /var/www/html/mb-doc
-  http://localhost/mb-doc/
-
-  # add, commit and push your new file to the mapbender-documentation repository
-  # replace <element_name> with the element name, dont forget to remove the <, >
-  git checkout -b feature/add_wms
-  git add en/functions/basic/add_wms.rst
-  git commit -m 'new documentation for element <element_name>'
-  git push --set-upstream origin feature/add_wms
-
-  # get the actual files from the mapbender-documentation repository
-  git checkout master
-  git pull
-
-
-
-Working with reStructured Text (rst)
-************************************
-
-For more info for rst-files and reStructured Text, take a look at these documentations:
-
-* `Wikipedia reStructured Text <https://en.wikipedia.org/wiki/ReStructuredText>`_
-* `reStructured Text on docutils at SourceForge <https://docutils.sourceforge.net/rst.html>`_
-* `Quick reStructuredText <https://docutils.sourceforge.net/docs/user/rst/quickref.html>`_

--- a/en/documentation_howto.rst
+++ b/en/documentation_howto.rst
@@ -8,85 +8,9 @@ Please take a look at the documentation files in this repository:
 
 https://github.com/mapbender/mapbender-documentation/
 
-
-How to build the documentation via Sphinx?
-******************************************
-We generate the website code from the rst-files using Sphinx.
+We generate the website code from the rst-files in the Mapbender documentation repostory using Sphinx.
 
 To build the website locally, you need to install Sphinx first. Find more information in the README.md file:
 
 https://github.com/mapbender/mapbender-documentation/blob/master/README.md
 
-
-Example for element documentation
-*********************************
-Let's assume that you are a developer and just added a new element to the Mapbender code base. In this example, your element is called AddWMS and is part of the Mapbender CoreBundle.
-
-**Now it is time to write the documentation!**
-
-Here are the steps you have to do:
-
-.. code-block:: bash
-
-  # Get the documentation files from GitHub:
-  cd /data
-  git clone git@github.com:mapbender/mapbender-documentation
-  cd /mapbender-documentation/en/functions/basic
-
-  # Create a rst-file. E.g., use the overview.rst as template for element documentation:
-  cp overview.rst basic/add_wms.rst
-
-  # Write the documentation: keep it short and simple.
-
-  # Build the documentation locally to see how your documentation looks like. Adjust the version number (if necessary).
-  cd /data/mapbender-documentation/
-  rm -Rf _build
-  sphinx-build . _build -A version=3.3.0
-
-  # Have a look at the documentation in your browser (example location). Is everything ok? Are any changes needed?
-  ln -s /data/mapbender-documentation/_build/ /var/www/html/mb-doc
-  http://localhost/mb-doc/
-
-  # Next, add, commit and push your new file to the mapbender-documentation repository:
-  git checkout -b feature/add_wms
-  git add en/functions/basic/add_wms.rst
-  git commit -m 'new documentation for element <element_name>'
-  git push --set-upstream origin feature/add_wms
-
-  # To get the actual files from the mapbender-documentation repository, run
-  git checkout master
-  git pull
-
-
-Images (figures)
-****************
-Images for the documentation are located at:
-
-* mapbender-documentation/figures
-* create images with size 800 x 600px (you can resize your browser window, e.g. with web developer to this size)
-* have a look at quickstart.rst to learn about image referring
-* for elements, use elementname.png and elementname_configuration.png as name. If you also provide german image files, please keep the names and create two more images in the de folder.
-
-
-Languages
-*********
-At last, all fully supported languages (i.e.: en - english, de - german) should have the same file structure.
-
-.. code-block:: yaml
-
-  /mapbender-documentation
-    index.rst          # refers to the different languages
-    /figures           # images that are included in the documentation
-    /de
-      ...
-    /en
-      index.rst        # refers to TheBook, Developer's Book & the Bundle Documentation
-      bundles.rst      # lists the chapters of this category - refers to rst files
-      development.rst  # lists the chapters of this category - refers to rst files
-      /architecture
-      /development
-          ....
-      /functions
-          /backend
-          /basic
-          ....


### PR DESCRIPTION
Shorten the user guide of how to write the documentation and move information into README.md (see issue #376 )