### PR TITLE
Adding more links within Quickstart page 

### DIFF
--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -183,40 +183,41 @@ Jetzt sollten sie eine Idee davon haben, wie einfach es ist, eine Mapbender-Anwe
 
 Im Folgenden finden Sie eine vollständige Liste aller Elemente inklusive ihrer Funktion. Detaillierte Informationen können Sie in den jeweiligen Kapiteln der `Mapbender Dokumentation <index.html>`_ nachlesen.
 
-* Aktivitätsanzeige: zeigt die HTTP-Aktivität an
-* Ansichtsverwaltung: speichert Kartenzustände zum späteren Abruf
-* Anwendung wechseln: wechselt unter Beibehaltung der aktuellen Kartenposition zu einer anderen Anwendung
-* Bildexport: exportiert einen Kartenausschnitt
-* Button: bindet ein Element als Button ein
-* Copyright: zeigt Nutzungsbedingungen an
-* Data manager: erzeugt und speichert Sachinformationen in einer Datenbank 
-* Digitizer: erzeugt und speichert Geometrieinformationen in einer Datenbank
-* Dimensions-Handler: bindet Dienste mit einer zeitlichen Dimension in die Anwendung ein
-* Druck: erzeugt einen Druckdialog, mit dem Karteninhalte als PDF exportiert und gedruckt werden können
-* Ebenenbaum: gibt eine Übersicht über alle eingebundenen Layersets und Layer
-* Einfache Suche: erstellt eine Einfeldsuche
-* GPS-Position: erzeugt einen Button zur Anzeige der eigenen GPS-Position
-* HTML: bietet die freie Definition von HTML zur Einbindung von Bildern, Texten oder Links
-* Hintergrund wechseln: ermöglicht den Wechsel zwischen selbst definierten Hintergrundkarten
-* Information: gibt Informationen eines Dienstes aus
-* Karte: erstellt ein zentrales Kartenelement, in welches die Layersets und Layer eingebunden sind
-* Koordinaten Utility: transformiert Koordinaten und navigiert zu ihnen auf der Karte
-* Koordinatenanzeige: zeigt Mausposition in den Kartenkoordinaten an
-* Legende: zeigt die Legende von aktiven Diensten an
-* Linien- und Flächenmessung: erlaubt das Messen von Linien und Flächen in der Karte
-* Link: verlinkt zu einer externen URL
-* Maßstabsanzeige: zeigt aktuellen Maßstab numerisch an
-* Maßstabsauswahl: gibt eine Auswahlbox mit den verfügbaren Maßstäben zum Wechseln dieser an
-* Maßstabsleiste: zeigt den aktuellen Maßstab graphisch an
-* MeetingPoint (POI): generiert einen Treffpunkt, welcher mit Hinweistexten und über eine URL verschickt wird
-* Navigationswerkzeug: ermöglicht die Navigation in der Karte über ein graphisches Steuerelement
-* SRS Auswahl: generiert die Möglichkeit, eine Projektion (SRS) über eine Auswahlbox zu wechseln
-* Skizzen: ermöglicht das Zeichnen verschiedener Formen in der Karte
-* Suchen: ermöglicht die Konfiguration von individuellen Suchen
-* URL teilen: teilt die aktuelle Kartenansicht über eine URL
-* WMS laden: lädt einen WMS per getCapabilities-Request
-* Über Mapbender-Dialog: zeigt Informationen über Mapbender an
-* Übersicht (overview): zeigt eine kleinere Übersichtskarte über der Hauptkarte an
+* :ref:`activity_indicator_de` : zeigt die HTTP-Aktivität an
+* :ref:`view_manager_de` : speichert Kartenzustände zum späteren Abruf
+* :ref:`applicationswitcher_de` : wechselt unter Beibehaltung der aktuellen Kartenposition zu einer anderen Anwendung
+* :ref:`imageexport_de` : exportiert einen Kartenausschnitt
+* :ref:`button_de` : bindet ein Element als Button ein
+* :ref:`copyright_de` : zeigt Nutzungsbedingungen an
+* :ref:`datamanager_de` : erzeugt und speichert Sachinformationen in einer Datenbank 
+* :ref:`digitizer_de` : erzeugt und speichert Geometrieinformationen in einer Datenbank
+* :ref:`dimensions_handler_de` : bindet Dienste mit einer zeitlichen Dimension in die Anwendung ein
+* :ref:`printclient_de` : erzeugt einen Druckdialog, mit dem Karteninhalte als PDF exportiert und gedruckt werden können
+* :ref:`layertree_de`: gibt eine Übersicht über alle eingebundenen Layersets und Layer
+* :ref:`simplesearch_de` : erstellt eine Einfeldsuche
+* :ref:`gpspostion_de` : erzeugt einen Button zur Anzeige der eigenen GPS-Position
+* :ref:`html_de`: bietet die freie Definition von HTML zur Einbindung von Bildern, Texten oder Links
+* :ref:`basesourceswitcher_de` : ermöglicht den Wechsel zwischen selbst definierten Hintergrundkarten
+* :ref:`feature_info_de`: gibt Informationen eines Dienstes aus
+* :ref:`map_de`: erstellt ein zentrales Kartenelement, in welches die Layersets und Layer eingebunden sind
+* :ref:`coordinate_utility_de` : transformiert Koordinaten und navigiert zu ihnen auf der Karte
+* :ref:`coordinates_display_de`: zeigt Mausposition in den Kartenkoordinaten an
+* :ref:`legend_de`: zeigt die Legende von aktiven Diensten an
+* :ref:`ruler_de` : erlaubt das Messen von Linien und Flächen in der Karte
+* :ref:`link_de`: verlinkt zu einer externen URL
+* :ref:`scaledisplay_de` : zeigt aktuellen Maßstab numerisch an
+* :ref:`scale_selector_de` : dieses Element zeigt eine Auswahlbox mit Maßstäben an.
+* :ref:`simplesearch_de` : gibt eine Auswahlbox mit den verfügbaren Maßstäben zum Wechseln dieser an
+* :ref:`scalebar_de`: zeigt den aktuellen Maßstab graphisch an
+* :ref:`poi_de` : generiert einen Treffpunkt, welcher mit Hinweistexten und über eine URL verschickt wird
+* :ref:`navigation_toolbar_de` : ermöglicht die Navigation in der Karte über ein graphisches Steuerelement
+* :ref:`srs_selector_de` : generiert die Möglichkeit, eine Projektion (SRS) über eine Auswahlbox zu wechseln
+* :ref:`sketch_de` : ermöglicht das Zeichnen verschiedener Formen in der Karte
+* :ref:`search_router_de` : ermöglicht die Konfiguration von individuellen Suchen
+* :ref:`shareurl_de` : teilt die aktuelle Kartenansicht über eine URL
+* :ref:`wms_loader_de` : lädt einen WMS per getCapabilities-Request
+* :ref:`about_dialog_de` : zeigt Informationen über Mapbender an
+* :ref:`overview_de` : zeigt eine kleinere Übersichtskarte über der Hauptkarte an
 
 
 Versuchen Sie es selbst

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -183,40 +183,43 @@ Now you should have an idea about how easy it is to change a Mapbender applicati
 
 In the following, you find a complete list of all elements and their functionalities. For a more detailed description, please have a look at the corresponding chapters in the `mapbender documentation <index.html>`_.
 
-* About dialog: Shows information about Mapbender in an about dialog
-* Activity indicator: Shows HTTP activity
-* Application switcher:	Switches to another application while maintaining the current map position
-* Base source switcher:	Changes the map's background sources
-* Button: Integrate another element as a button
-* Coordinates display: Shows the map coordinates of your mouse position
-* Coordinates utility: Transforms coordinates to different SRS and navigates to them on the map
-* Copyright: Shows terms of use
-* Data manager: Create and manage non-spatial data
-* Digitizer: Create and manage spatial data
-* Dimensions handler: Manage sources with a time dimension
-* FeatureInfo: Gives information about sources
-* GPS Position: Renders a button to show the GPS position
-* HTML: Offers free definition of HTML to integrate pictures, texts or links			
-* Image export: Exports the current map view (format options: png or jpeg)
-* Layer tree: Gives an overview of map layersets and layers
-* Legend: Displays legend of active themes on the map
-* Line/Area Ruler: Enables to measure a line/area and display its length/area in a dialog
-* Link: Links to an external URL
-* Map: Creates the map element in which layersets and layers are integrated into
-* Navigation toolbar: Provides a floating control to pan and zoom in the map
-* Overview: Provides an overview map
-* POI: Creates a POI for sharing
-* Print client: Renders a Print dialog
-* SRS selector: Changes the map's spatial reference system
-* Scale bar: Displays a small line indicator representing the current map scale
-* Scale display: Displays the current map scale
-* Scale selector: Displays and changes a map scale
-* Search router: Enables a configurable search via SQL
-* Share URL: Shares the current map view via URL
-* Simple Search: Enables a configurable search on JSON sources (e.g. Solr)
-* Sketches: Enables a drawing tool with different shapes
-* View manager: Saves map states for later restoration
-* WMS loader: Loads a WMS via a getCapabilities-Request
+* :ref:`about_dialog` :  Shows information about Mapbender in an about dialog
+* :ref:`activity_indicator` : Shows HTTP activity
+* :ref:`view_manager` : Saves map states for later restoration
+* :ref:`applicationswitcher` : Switches to another application while maintaining the current map position
+* :ref:`imageexport` : Exports the current map view (format options: png or jpeg)
+* :ref:`button` : Integrate another element as a button
+* :ref:`copyright` : Shows terms of use
+* :ref:`datamanager` : erzeugt und speichert Sachinformationen in einer Datenbank 
+* :ref:`digitizer` : Create and manage spatial data
+* :ref:`dimensions_handler` : Manage sources with a time dimension
+* :ref:`printclient` : Renders a Print dialog
+* :ref:`layertree`: Gives an overview of map layersets and layers
+* :ref:`simplesearch` : erstellt eine Einfeldsuche
+* :ref:`gpspostion` : Renders a button to show the GPS position
+* :ref:`html`: Offers free definition of HTML to integrate pictures, texts or links	
+* :ref:`basesourceswitcher` : Changes the map's background sources
+* :ref:`feature_info`: Gives information about sources
+* :ref:`map`: Creates the map element in which layersets and layers are integrated into
+* :ref:`coordinate_utility` : Transforms coordinates to different SRS and navigates to them on the map
+* :ref:`coordinates_display`: Shows the map coordinates of your mouse position
+* :ref:`legend`: Displays legend of active themes on the map
+* :ref:`ruler` : Enables to measure a line/area and display its length/area in a dialog
+* :ref:`link`: Links to an external URL
+* :ref:`scaledisplay` : Displays the current map scale
+* :ref:`simplesearch` : Enables a configurable search on JSON sources (e.g. Solr)
+* :ref:`scalebar`: Displays a small line indicator representing the current map scale
+* :ref:`scale_selector`: Displays and changes a map scale
+* :ref:`poi` : Creates a POI for sharing
+* :ref:`navigation_toolbar` : Provides a floating control to pan and zoom in the map
+* :ref:`srs_selector` : Changes the map's spatial reference system
+* :ref:`sketch` : Enables a drawing tool with different shapes
+* :ref:`search_router` : Enables a configurable search via SQL
+* :ref:`shareurl` : Shares the current map view via URL
+* :ref:`wms_loader` : Loads a WMS via a getCapabilities-Request
+* :ref:`about_dialog` : Shows information about Mapbender in an about dialog
+* :ref:`overview` : Provides an overview map
+
 
 
 Try it yourself


### PR DESCRIPTION
this PR adds links between different `reStructuredText (.rst)` files using the inline markup provided by sphinx. All elements and their functionalities on the list are linked to their pages.

**To achieve this**

   define its label on top of the file:
    
          .. _activity_indicator:
    
   then you can link to it from other documents using:  
           
         :ref:`activity_indicator`
