### PR TITLE
Edit docs to use unified crosslink tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ Now, take a look at the documentation page in your browser. Is everything ok? Ar
 
 Below you'll find some basic conventions about documentation writing.
 
+### Crosslinks
+
+Create crosslinks to refer to another documentation page with a label. Labels that refer to a page are always in the first line of the file. Feel free to add labels above headings, if you want to refer to these instead.
+
+```bash
+    .. _activity_indicator:
+```
+
+Add the crosslink to your documentation text section like this:
+
+```bash
+    After this text is a link to :ref:`activity_indicator`.
+```
+
+Note that German labels always use the `_de` suffix.
+
 ### Images (figures)
 
 Images for the documentation are located at mapbender-documentation/figures

--- a/de/backend/FOM/security.rst
+++ b/de/backend/FOM/security.rst
@@ -5,15 +5,15 @@ Sicherheitskonzepte
 
 Sicherheit wird im FOM User Bundle bereitgestellt und basiert auf diesen Konzepten:
 
-- :doc:`Benutzer <users>`
-- :doc:`Rollen und Gruppen <roles_groups>`
-- :doc:`Access Control Lists (ACL) <acl>`
+- :ref:`users_de`
+- :ref:`roles_groups_de`
+- :ref:`acl_de`
 
 
 Rechte
 ******
 
-Mapbender bietet verschiedene Rechte an, die Sie vergeben können. Sie basieren auf :doc:`Access Control Lists (ACL) <acl>`.
+Mapbender bietet verschiedene Rechte an, die Sie vergeben können. Sie basieren auf :ref:`acl_de`.
 
 * view - anzeigen
 * edit - editieren

--- a/de/backend/applications/layerset.rst
+++ b/de/backend/applications/layerset.rst
@@ -1,5 +1,8 @@
 .. _layerset_de:
 
+Layerset
+********
+
  .. |mapbender-button-add| image:: ../../../figures/mapbender_button_add.png
 
  .. |mapbender-button-checkbox| image:: ../../../figures/mapbender_button_checkbox.png
@@ -10,13 +13,8 @@
 
  .. |mapbender-button-publish| image:: ../../../figures/mapbender_button_publish.png
 
-
-Layerset
-********
-
 Ein Layerset ist ein logischer Container, der einen oder mehrere Layerset-Instanzen (WMS-Dienste) beinhalten kann.
 In den Demo-Anwendungen sind zwei Layersets definiert: Das Layerset "Main" für die Hauptkarte und das Layerset "Overview" für die Übersichtskarte. Die Namen der Layersets können frei gewählt werden. Außerdem können mehrere Layersets im Kartenelement ausgewählt werden. Zudem zeigt der Ebenenbaum den Namen der Layersets an, wenn die Option der thematischen Layer aktiviert ist.
-
 
 Layerset-Übersichtsseite
 ========================

--- a/de/backend/sources.rst
+++ b/de/backend/sources.rst
@@ -2,6 +2,7 @@
 
 Datenquellen (Sources)
 ======================
+
 Über den Backend-Menübereich Datenquellen können OGC WMS- und WMTS/TMS-Dienste in den Versionen 1.1.1 und 1.3.0 registriert werden.
 
 Informationen zum Einbinden von Diensten und die Nutzung in Anwendungen finden Sie im `Quickstart Dokument <../../quickstart.html#laden-von-datenquellen>`_.

--- a/de/backend/sources.rst
+++ b/de/backend/sources.rst
@@ -5,7 +5,7 @@ Datenquellen (Sources)
 
 Über den Backend-Menübereich Datenquellen können OGC WMS- und WMTS/TMS-Dienste in den Versionen 1.1.1 und 1.3.0 registriert werden.
 
-Informationen zum Einbinden von Diensten und die Nutzung in Anwendungen finden Sie im `Quickstart Dokument <../../quickstart.html#laden-von-datenquellen>`_.
+Informationen zum Einbinden von Diensten und die Nutzung in Anwendungen finden Sie im Schnellstart-Kapitel :ref:`load_sources_de`.
 
 
 Datenquelle laden

--- a/de/backend/sources.rst
+++ b/de/backend/sources.rst
@@ -1,11 +1,7 @@
 .. _sources_de:
 
-  .. |mapbender-button-add| image:: ../../figures/mapbender_button_add.png
-  .. |mapbender-button-update| image:: ../../figures/mapbender_button_update.png
-
 Datenquellen (Sources)
 ======================
-
 Über den Backend-Menübereich Datenquellen können OGC WMS- und WMTS/TMS-Dienste in den Versionen 1.1.1 und 1.3.0 registriert werden.
 
 Informationen zum Einbinden von Diensten und die Nutzung in Anwendungen finden Sie im `Quickstart Dokument <../../quickstart.html#laden-von-datenquellen>`_.
@@ -16,7 +12,8 @@ Datenquelle laden
 
 .. tip:: **Hinweis**: Es ist wichtig, dass die Datenquelle vor dem Hochladen auf ihre Richtigkeit überprüft wird. Dies erfolgt über den Aufruf des getCapabilities-Requests im Browser.
 
-
+  .. |mapbender-button-add| image:: ../../figures/mapbender_button_add.png
+    
 Um einen Dienst zu laden, drücken Sie auf |mapbender-button-add| **Datenquelle hinzufügen**. Dies öffnet einen Konfigurationsbereich mit folgenden Parametern:
 
 * **Typ**: Dropdown-Auswahl zwischen Datentyp OGC WMS und OGC WMTS / TMS (Pflichtangabe).
@@ -67,6 +64,8 @@ Im Metadatendialog eines Dienstes befindet sich oben rechts außerdem das Datenq
 
 Datenquellen aktualisieren
 --------------------------
+  .. |mapbender-button-update| image:: ../../figures/mapbender_button_update.png
+
 Die Aktualisierung einer Datenquelle erfolgt zunächst über den Aufruf der Seite ``Datenquellen`` im Backend.
 Wählen Sie aus der Liste die zu aktualisierende Datenquelle aus. Es ist möglich, die Liste anhand des Suchfelds nach Diensten zu filtern.
 Klicken Sie anschließend neben der gewünschten Datenquelle auf den |mapbender-button-update| **Datenquelle aktualisieren**-Button.

--- a/de/customization/commands.rst
+++ b/de/customization/commands.rst
@@ -190,8 +190,7 @@ Der Druck in der Warteschlange ist standardmäßig deaktiviert, da er eine exter
 
 	mapbender.print.queueable: true
 
-Weitere Informationen zum Warteschleifendruck können Sie hier nachlesen https://doc.mapbender.org/de/functions/export/printclient.html#warteschleifendruck
-sowie https://github.com/mapbender/mapbender/pull/1070
+Weitere Informationen gibt es im Kapitel :ref:`queued_print_de` sowie unter https://github.com/mapbender/mapbender/pull/1070.
 
 Anschließend wird im Backend des Mapbenders der Druckassistent aktualisiert und es erscheinen zwei neue Zeilen, Modus und Warteschleife.
 
@@ -602,6 +601,8 @@ Aktualisiert den Hostnamen in den Quell-URLs, ohne die Funktionen/Capabilities n
 	14 urls unchanged
    
     
+
+.. _mapbender_config_check_de:
 
 app/console mapbender:config:check 
 **********************************

--- a/de/customization/templates.rst
+++ b/de/customization/templates.rst
@@ -7,7 +7,7 @@ Mapbender beinhaltet bereits Anwendungs-Vorlagen, sie befinden sich im Mapbender
 Häufig sollen jedoch eigene Anwendungs-Vorlagen und Administrationsoberflächen mit eigenem Corporate Design verwendet werden.
 Um Probleme bei einem Upgrade zu vermeiden, sollte für personalisierte Oberflächen ein eigenes Bundle verwendet werden.
 
-Der Stil einer einzelnen Anwendung kann ebenfalls über den :ref:`CSS-Editor <css_de>` angepasst werden.
+Der Stil einer einzelnen Anwendung kann ebenfalls über den :ref:`css_de` angepasst werden.
 
 
 Wie werden eigene Vorlagen erzeugt?

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -187,7 +187,7 @@ Eine Konfiguration könnte wie folgt aussehen:
     locale:            de    
     secret:            ThisTokenIsNotSoSecretChangeIt
 
-Weitere Informationen unter https://doc.mapbender.org/en/architecture/translation.html
+Weitere Informationen unter :ref:`translation`.
 
 
 SSL Zertifikat
@@ -331,7 +331,7 @@ Fußzeile
     * © OpenStreetMap contributors (Button)
     * HTML-powered by Mapbender (HTML)
 
-Ausführliche Beschreibungen der einzelnen Funktionen unter https://doc.mapbender.org/de/functions.html
+Ausführliche Beschreibungen der einzelnen Funktionen unter :ref:`functions_de`.
 
 
 
@@ -349,7 +349,7 @@ Sidepane
 Kartenbereich
     Statt der Funktionen 'Maßstabsanzeige' und 'POI' ist die Funktion 'Koordinaten Utility' eingebunden.
 
-Ausführliche Beschreibungen der einzelnen Funktionen unter https://doc.mapbender.org/de/functions.html
+Ausführliche Beschreibungen der einzelnen Funktionen unter :ref:`functions_de`.
 
 
 

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -217,7 +217,7 @@ Wichtig: Jede Datenbank, die in der ``parameters.yml`` definiert wird, muss auch
                 driver:    "%database_driver%"              # Mehr Information unterhalb des Codes
                 host:      "%database_host%"                # Der Host, auf dem die Datenbank läuft. Entweder der Name (z.B. localhost) oder die IP-Adresse (z.B. 127.0.0.1).
                 port:      "%database_port%"                # Der Port, auf dem die Datenbank lauscht (z.B. 5432 für PostgreSQL).
-                dbname:    "%database_name%"                # Der Name der Datenbank (z.B. mapbender). Erstellen Sie die Datenbank mit dem Befehl ``doctrine:database:create`` bzw. ``doctrine:schema:create``. Siehe die `Installationsanleitung <../installation.html>`_ für Details.
+                dbname:    "%database_name%"                # Der Name der Datenbank (z.B. mapbender). Erstellen Sie die Datenbank mit dem Befehl ``doctrine:database:create`` bzw. ``doctrine:schema:create``.
                 path:      "%database_path%"                # Der %database_path% ist der Pfad zur Datei der SQLite-Datenbank. Wenn Sie keine SQLite-Datenbank verwenden, schreiben Sie als Wert entweder eine Tilde (~) oder ``null``.
                 user:      "%database_user%"                # Benutzername für die Verbindung zur Datenbank.
                 password:  "%database_password%"            # Das Passwort des Datenbankbenutzers.

--- a/de/development/introduction.rst
+++ b/de/development/introduction.rst
@@ -20,8 +20,7 @@ Sie sollten einige Dinge wissen, um an der Mapbender-Entwicklung mitwirken zu k√
 Installation
 ************
 
-Die Installation aus den Git-Quellen ist im Kapitel `Git-basierte Installation <../installation/installation_git.html>`_ beschrieben.
-
+Die Installation aus den Git-Quellen heraus wird unter :ref:`Git-basierte Installation <installation_git_de>` beschrieben.
 
 
 Wo gibt es Hilfe?

--- a/de/faq.rst
+++ b/de/faq.rst
@@ -13,7 +13,7 @@ F: Wozu sind die unterschiedlichen Umgebungen da?
 
 A: Für den gewöhnlichen produktiven Einsatz rufen Sie Mapbender über die app.php-Datei auf. Erst wenn Sie selbst etwas (an den Twig-, CSS- oder JS-Dateien) entwickeln, nutzen Sie den Aufruf über die app_dev.php-Datei. Der dahinterstehende Entwicklungsmodus gibt mehr Informationen aus, indem er z. B. detailliertere Fehlermeldungen anzeigt. 
 
-Mehr Details zu den Umgebungen gibt es im Kapitel `Produktions- und Enwicklungsumgebung und Caches: app.php und app_dev.php <installation/installation_configuration.html#produktions-und-entwicklungsumgebung-und-caches-app-php-und-app-dev-php>`_.
+Mehr Details zu den Umgebungen gibt es im Kapitel :ref:`app_cache_de`.
 
 
 Cache
@@ -25,7 +25,7 @@ A: Der Cache ist ein Zwischenspeicher, aus dem Mapbender auf häufig benutzte Da
 
 Diese zwei Verzeichnisse können ohne Bedenken gelöscht werden. Beim nächsten Aufruf von Mapbender werden im Cache der entsprechenden Umgebung erneut Dateien abgelegt.
 
-Mehr Details zum Cache gibt es im Kapitel `Produktions- und Entwicklungsumgebung und Caches: app.php und app_dev.php <installation/installation_configuration.html#produktions-und-entwicklungsumgebung-und-caches-app-php-und-app-dev-php>`_.
+Mehr Details zum Cache gibt es im Kapitel :ref:`app_cache_de`.
 
 
 Dienste in Anwendungen

--- a/de/faq.rst
+++ b/de/faq.rst
@@ -120,7 +120,7 @@ Weisen Sie zur Veränderung der Höhe diesem Parameter einen Wert zu:
 Problem bei WMS-Diensten mit vielen Layern
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-F: Beim Laden eines WMS mit vielen Layern (über 100) in eine Anwendung werden in der Konfiguration der `Layerset-Instance <backend/applications/layerset.html>`_  nur Teile der Layer übernommen und angezeigt. Die WMS-Instance kann außerdem nicht abgespeichert werden. Gibt es einen Weg, den WMS dennoch zu verwenden?
+F: Beim Laden eines WMS mit vielen Layern (über 100) in eine Anwendung werden in der :ref:`layerset`-Konfiguration nur Teile der Layer übernommen und angezeigt. Die WMS-Instance kann außerdem nicht abgespeichert werden. Gibt es einen Weg, den WMS dennoch zu verwenden?
 
 A: Mittels des PHP-Parameters `max-input_vars <https://php.net/manual/de/info.configuration.php#ini.max-input-vars>`_ kann die Zahl der Eingabe-Variablen erhöht werden. Der Standardwert liegt bei 1000. 
 Die Zahl der Eingabe-Variablen ist bei einem WMS mit vielen Layern sehr hoch, vergleichbar mit der Anzahl der Auswahlmöglichkeiten innerhalb des WMS-Instance-Dialogs. Setzen Sie bei der Arbeit mit großen WMS mit vielen Layern den Parameter hoch, beispielsweise auf 2000. Die Zahl hängt direkt mit der Anzahl der Layer im WMS zusammen.

--- a/de/functions/basic/coordinates_display.rst
+++ b/de/functions/basic/coordinates_display.rst
@@ -3,7 +3,7 @@
 Koordinatenanzeige (Coordinates Display)
 ****************************************
 
-Das Koordinatenanzeige-Element zeigt die Kartenkoordinaten der aktuellen Mausposition an. Die Koordinaten sind abhängig vom eingestellten räumlichen Referenzsystem, welches im `Spatial Reference System Selector <srs_selector.html>`_ geändert werden kann.
+Das Koordinatenanzeige-Element zeigt die Kartenkoordinaten der aktuellen Mausposition an. Die Koordinaten sind abhängig vom eingestellten räumlichen Referenzsystem, welches im :ref:`srs_selector_de` geändert werden kann.
 
 So sieht die Koordinatenanzeige für unterschiedliche Koordinatensysteme aus:
 

--- a/de/functions/basic/feature_info.rst
+++ b/de/functions/basic/feature_info.rst
@@ -35,7 +35,7 @@ Konfiguration
 * **Hover-Opazität (%) der Füllfarbe** Setzt die Opazität der Füllfarbe in Prozent beim Hovern.
 * **Hover-Linienstärke (in Pixeln)** Setzt die Breite der Umrandungslinie in Pixeln beim Hovern.
 
-Für das Element wird zudem ein Button benötigt. Zu der Konfiguration des Buttons besuchen sie die Dokumentationsseite unter `Button <../misc/button.html>`_.
+Für das Element wird zudem ein Button benötigt. Zu der Konfiguration des Buttons besuchen sie die Dokumentationsseite unter :ref:`button_de`.
 
 Einstellungen im Ebenenbaum
 ---------------------------

--- a/de/functions/basic/layertree.rst
+++ b/de/functions/basic/layertree.rst
@@ -30,9 +30,9 @@ Funktionen
 
 Zur Konfiguration des Ebenenbaums gibt es verschiedene Verknüpfungspunkte zu anderen Elementen, die beachtet werden müssen: 
 
-* `Layersets <../../backend/applications/layerset.html>`_
-* `Kartenelement <map.html>`_
-* `Datenquellen <../../backend/sources.html>`_
+* :ref:`layerset_de`
+* :ref:`map_de`
+* :ref:`sources_de`
 
 
 Konfiguration
@@ -50,7 +50,7 @@ Um Layersets im Ebenenbaum nutzen zu können, sind verschiedene Anpassungen notw
 Über den Reiter **Layerset** können Layersets definiert und Datenquellen in eine Anwendung eingebunden werden. 
 
 Die Instanzen sind die Referenzen auf die einzelnen WMS-Dienste. Über den großen ``+``-Button kann ein neues Layerset hinzugefügt werden. In dieses lassen sich im Anschluss neue Layer über das Hinzufügen von im Backend registrierten Instanzen einbinden. Das Layerset "overview" wird im Beispiel für die Anzeige der Übersichtskarte verwendet. 
-Eine Dokumentation, wie die Dienste korrekt registriert und eingebunden werden, findet sich unter der `Datenquellen <../../backend/sources.html>`_ und `Layersets <../../backend/applications/layerset.html>`_. 
+Eine Dokumentation, wie die Dienste korrekt registriert und eingebunden werden, findet sich unter :ref:`sources_de` und :ref:`layerset_de`. 
 
 
 .. figure:: ../../../figures/de/mapbender_add_source_to_application.png
@@ -59,7 +59,7 @@ Eine Dokumentation, wie die Dienste korrekt registriert und eingebunden werden, 
 
            Einrichtung von Layersets für die Einbindung in den Ebenenbaum.
 
-Damit die neu eingebundenen Layersets auch in der Anwendung erscheinen, müssen diese im `Kartenelement <map.html>`_ angegeben werden. 
+Damit die neu eingebundenen Layersets auch in der Anwendung erscheinen, müssen diese im :ref:`Kartenelement <map_de>` angegeben werden. 
 Durch das Aktivieren der gewünschten Layersets wird definiert, ob diese in der Kartenansicht verwendet werden. 
 Auch wird hierüber die Reihenfolge definiert, in der die Layersets im Ebenenbaum und in der Karte erscheinen: Die Einträge in der Auflistung können per Drag & Drop verschoben werden.
 
@@ -87,7 +87,7 @@ Im Beispiel ist ein **Layerset** mit einer Instanz definiert:
     * Instanz OSM Demodienst https://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0
 
 Die registrierte Instanz des OSM-Demodienstes wird bei der Installation von Mapbender bereits mitgeliefert. Diese muss nur noch über den Anwendungsreiter **Layerset** in ein Layerset eingebunden werden. Im Beispiel wurde das Layerset "World" genutzt. 
-Bei Schwierigkeiten bei der Einbindung kann die Dokumentation der `Layersets <../../backend/applications/layerset.html>`_ weiterhelfen. 
+Bei Schwierigkeiten bei der Einbindung kann die Dokumentation der :ref:`layerset_de` weiterhelfen. 
 
 .. figure:: ../../../figures/layertree/layertree_configuration_layerset_simple.png
            :scale: 80
@@ -97,10 +97,10 @@ Bei Schwierigkeiten bei der Einbindung kann die Dokumentation der `Layersets <..
 
 **Einrichtung in der Karte zur Anzeige des Layersets**
 
-Als Nächstes erfolgt die Einrichtung des `Kartenelements <map.html>`_ zur Anzeige des Layersets in der **Karte**. Dazu wechseln wir in den Anwendungsreiter **Layouts** und bearbeiten dann das Kartenelement im Kartenbereich.
+Als Nächstes erfolgt die Einrichtung des :ref:`Kartenelements <map_de>` zur Anzeige des Layersets in der **Karte**. Dazu wechseln wir in den Anwendungsreiter **Layouts** und bearbeiten dann das Kartenelement im Kartenbereich.
 Wichtig ist, dass im Bereich Layersets das Layerset World aktiviert wird, damit es in der Anwendung angezeigt wird. 
 
-Bei Fragen zur weiteren Konfiguration der Karte kann die Dokumentation des `Kartenelements <map.html>`_ weiterhelfen.
+Bei Fragen zur weiteren Konfiguration der Karte kann die Dokumentation des :ref:`Kartenelements <map_de>` weiterhelfen.
 
 .. figure:: ../../../figures/layertree/layertree_configuration_map_simple.png
            :scale: 80 
@@ -185,7 +185,7 @@ In dem folgenden Beispiel sind zwei **Layersets** mit jeweils zwei Instanzen def
     * Instanz `OSM Demodienst <https://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_
     * Instanz `GEBCO <https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_ 
 
-Für die Einrichtung der Layersets wurden die vier oben genannten Dienste als Instanzen hinzugefügt (detaillierte Information siehe oben oder in der Doku der `Layersets <../../backend/applications/layerset.html>`_ und `Dienste <../backend/sources.html>`_).
+Für die Einrichtung der Layersets wurden die vier oben genannten Dienste als Instanzen hinzugefügt (detaillierte Information siehe oben oder in der Doku der :ref:`layerset_de` und `Dienste <../backend/sources.html>`_).
 
 Für dieses Beispiel wurden die oben genannten Schritte durchgeführt, um das Layerset "World" **[3]** mit der Instanz "osm" hinzuzufügen. Nun fügen wir in dieses Layerset die Instanz "GEBCO" hinzu. 
 Um die thematische Gruppierung nutzen zu können, erstellen wir zusätzlich ein neues Layerset mit dem Namen "Project NRW" **[2]** und laden in dieses die beiden oben genannten Instanzen "DTK50 NRW" und "Wald NRW" ein.
@@ -200,10 +200,10 @@ Das Layerset sollte nun drei Layersets enthalten. Die **Overview** [1] für die 
 
 **Einrichtung in der Karte zur Anzeige der Layersets**
 
-Als Nächstes erfolgt die Einrichtung des `Kartenelements <map.html>`_ zur Anzeige des Layersets in der Karte. Dazu wechseln wir in den Reiter "Layouts" und bearbeiten das Kartenelement im Kartenbereich.
+Als Nächstes erfolgt die Einrichtung des :ref:`Kartenelements <map_de>` zur Anzeige des Layersets in der Karte. Dazu wechseln wir in den Reiter "Layouts" und bearbeiten das Kartenelement im Kartenbereich.
 Wichtig ist, dass bei dem Bereich Layersets beide Layersets "World" und "Project NRW" per Checkbox aktiviert sind, damit diese in der Anwendung angezeigt werden. 
 
-Bei Fragen zur weiteren Konfiguration der Karte kann die Dokumentation des `Kartenelements <map.html>`_ weiterhelfen.
+Bei Fragen zur weiteren Konfiguration der Karte kann die Dokumentation des :ref:`Kartenelements <map_de>` weiterhelfen.
 
 .. figure:: ../../../figures/layertree/layertree_configuration_map_komplex.png
            :scale: 80 

--- a/de/functions/basic/layertree.rst
+++ b/de/functions/basic/layertree.rst
@@ -131,7 +131,7 @@ Wenn **Automatisches Öffnen** aktiv ist, wird der Ebenenbaum beim Anwendungssta
 * *Opacity* (Deckkraft eines einzelnen Layers verändern)
 * *Zoom to layer* (Layer zentriert in seiner vollen Ausdehnung anzeigen)
 * *Metadata* (Metadaten eines Layers anzeigen)
-* *Dimension* (Dimension eines Layers kontrollieren - mehr Informationen unter `Dimensions handler <../misc/dimensions_handler.html>`_ )
+* *Dimension* (Dimension eines Layers kontrollieren - mehr Informationen unter :ref:`dimensions_handler_de` )
 
 .. figure:: ../../../figures/layertree/layertree_menu.png
            :scale: 80
@@ -185,7 +185,7 @@ In dem folgenden Beispiel sind zwei **Layersets** mit jeweils zwei Instanzen def
     * Instanz `OSM Demodienst <https://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_
     * Instanz `GEBCO <https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_ 
 
-Für die Einrichtung der Layersets wurden die vier oben genannten Dienste als Instanzen hinzugefügt (detaillierte Information siehe oben oder in der Doku der :ref:`layerset_de` und `Dienste <../backend/sources.html>`_).
+Für die Einrichtung der Layersets wurden die vier oben genannten Dienste als Instanzen hinzugefügt (detaillierte Information siehe oben oder in der Doku der :ref:`layerset_de` und :ref:`sources_de`).
 
 Für dieses Beispiel wurden die oben genannten Schritte durchgeführt, um das Layerset "World" **[3]** mit der Instanz "osm" hinzuzufügen. Nun fügen wir in dieses Layerset die Instanz "GEBCO" hinzu. 
 Um die thematische Gruppierung nutzen zu können, erstellen wir zusätzlich ein neues Layerset mit dem Namen "Project NRW" **[2]** und laden in dieses die beiden oben genannten Instanzen "DTK50 NRW" und "Wald NRW" ein.
@@ -216,7 +216,7 @@ Bei Fragen zur weiteren Konfiguration der Karte kann die Dokumentation des :ref:
 Als letzter Schritt erfolgt die Einrichtung des Ebenenbaums selbst. Für den thematischen Ebenenbaum binden wir den Ebenenbaum in diesem Beispiel in die Sidepane ein.
 
 Ist die Option **Thematischer Layer** ausgeschaltet, benutzt der Ebenenbaum nicht die konfigurierten Layersets und zeigt die einzelnen Instanzen ohne thematische Strukturierung in der Hauptebene an. Nun wollen wir jedoch die Layer über unsere thematischen Layersets anzeigen, daher aktivieren wir die Funktion **Thematischer Layer**. 
-Da wir im `Kartenelement <map.html>`_ beide Layersets in die Anwendung eingebunden haben, werden diese nun unter dem **Themen**-Bereich angezeigt.
+Da wir in der :ref:`map_de` beide Layersets in die Anwendung eingebunden haben, werden diese nun unter dem **Themen**-Bereich angezeigt.
 
 .. figure:: ../../../figures/layertree/layertree_configuration_2.png
            :scale: 80 

--- a/de/functions/basic/legend.rst
+++ b/de/functions/basic/legend.rst
@@ -21,7 +21,7 @@ Konfiguration
 * **Titel der Ebene anzeigen:** zeigt den Layertitel (Standard: true).
 * **Titel der gruppierten Ebenen anzeigen:** zeigt den Gruppenlayertitel für gruppierte Layer (Standard: true).
 
-Für das Element wird ein Button oder die Sidepane verwendet. Zu der Konfiguration des Buttons besuchen sie die Dokumentationsseite unter `Button <../misc/button.html>`_.
+Für das Element wird ein Button oder die Sidepane verwendet. Zu der Konfiguration des Buttons besuchen sie die Dokumentationsseite unter :ref:`button_de`.
 
 
 Konfigurationsbeispiele
@@ -61,7 +61,7 @@ Für das Konfigurationsbeispiel wurden folgende Einstellungen gewählt:
      :scale: 80
 
 Für das Konfigurationsbeispiel wurde das Häkchen bei *Automatisches Öffnen* entfernt, sodass sich die Legende nur bei aktivem Klicken auf einen Button öffnet.
-Sobald dieses Element im Kartenbereich eingebunden wurde, muss ein Button in der oberen Werkzeugleiste eingefügt werden. Die Konfiguration von Buttons wird in der Mapbender-Dokumentation unter `Button <../misc/button.html>`_ beschrieben.
+Sobald dieses Element im Kartenbereich eingebunden wurde, muss ein Button in der oberen Werkzeugleiste eingefügt werden. Die Konfiguration von Buttons wird in der Mapbender-Dokumentation unter :ref:`button_de` beschrieben.
 
 Die Konfiguration eines Buttons für die Legende kann wie folgt aussehen:
 

--- a/de/functions/basic/navigation_toolbar.rst
+++ b/de/functions/basic/navigation_toolbar.rst
@@ -6,13 +6,13 @@ Navigationswerkzeug (Navigation Toolbar)
 Das Element erleichtert die Navigation in der Karte durch Rotation und Zoom. Der Kartenmaßstab kann individuell über eine Leiste angesprungen oder über die Zoom in/out-Buttons abgeändert werden. Es besteht zudem die Möglichkeit, auf die maximale Kartenausdehnung zu zoomen oder zum Anfangszustand zurück zu navigieren. Das Navigationselement selbst ist verschiebbar.
 
 .. image:: ../../../figures/de/navigation_toolbar.png
-     :scale: 80
+   :scale: 80
 
 Konfiguration
 =============
 
 .. image:: ../../../figures/de/navigation_toolbar_configuration.png
-     :scale: 80
+   :scale: 80
 
 * **Verschiebbar:** Navigationswerkzeug ist verschiebbar oder nicht (Standard: true).
 * **Title:** Titel des Elements. Dieser wird in der Layouts Liste angezeigt.
@@ -33,21 +33,21 @@ Im Konfigurationsdialog können unterschiedliche Komponenten (*Components*), als
 Die Komponenten sehen in der Anwendung wie folgt aus:
 
 .. image:: ../../../figures/de/navigationtoolbar_features.png
-     :scale: 80
+   :scale: 80
 
 Wenn das Häkchen bei **Verschiebbar** gesetzt wurde, dann erscheint in der Anwendung ein kleines Kreuzsymbol zur Verschiebung des Navigationselements.
 
 Mit **Rotation** kann die Ausrichtung der Karte verändert werden. Durch Klick auf den Nordpfeil ist es möglich, die Standardrotation (Nordausrichtung) wiederherzustellen.
 
-Es besteht die Möglichkeit, mit **Zoom to max extent** auf den kleinsten Maßstab zu zoomen. Dieser *Max Extent* wird vom Nutzer selbst innerhalb des `Kartenelements <map.html>`_ im Kartenbereich definiert.
+Es besteht die Möglichkeit, mit **Zoom to max extent** auf den kleinsten Maßstab zu zoomen. Dieser *Max Extent* wird vom Nutzer selbst innerhalb des :ref:`Kartenelements <map_de>` im Kartenbereich definiert.
 
 .. image:: ../../../figures/de/navigationtoolbar_zoom_to_max.png
-     :scale: 80
+   :width: 100%
 
 Nutzer können außerdem die anfänglichen Einstellungen von Maßstab, Koordinatenreferenzsystem, Rotation und Zentrierung mit **Zurück zum Anfang** wiederherstellen.
 
 .. image:: ../../../figures/de/navigationtoolbar_zoom_to_start.png
-     :scale: 80
+   :width: 100%
 
 **Zoom in/out** ermöglicht durch einen Klick auf das ``+`` -Zeichen ein Hineinzoomen, sowie durch einen Klick auf das ``–`` -Zeichen ein Hinauszoomen aus der Karte. Der Kartenausschnitt springt dabei immer zum jeweils nächstgrößeren bzw. -kleineren Maßstab. Je nach Definition im Kartenelement sind größere oder kleinere Zoomschritte möglich. Nutzer haben außerdem die Möglichkeit, feste Zoomstufen im Kartenelement zu deaktivieren.
 Die Komponente **Zoom slider** beinhaltet automatisch die Komponente *Zoom in/out*, in welcher auch ``+`` und ``–`` -Zeichen zur Verfügung stehen. Zusätzlich besteht diese Komponente aus einer Leiste, die die möglichen Zoomstufen als auswählbare Punkte anzeigt.

--- a/de/functions/basic/srs_selector.rst
+++ b/de/functions/basic/srs_selector.rst
@@ -4,7 +4,7 @@ SRS Auswahl (SRS Selector)
 **************************
 
 Mit der SRS Auswahl kann das räumliche Referenzsystem (SRS) der Karte geändert werden.
-Nach der Konfiguration stehen die Koordinatensysteme der Karte in einer Selectbox zur Auswahl, die vorher im `Kartenelement <map.html>`_ definiert wurden.
+Nach der Konfiguration stehen die Koordinatensysteme der Karte in einer Selectbox zur Auswahl, die vorher im :ref:`Kartenelement <map_de>` definiert wurden.
 
 .. image:: ../../../figures/srs_selector.png
      :scale: 100

--- a/de/functions/editing/datamanager.rst
+++ b/de/functions/editing/datamanager.rst
@@ -3,7 +3,7 @@
 Data Manager
 ************
 
-Der Data Manager ähnelt in seiner Funktionalität dem `Digitizer <digitizer.html>`_. Der Data Manager speichert allerdings nur Sachdaten und keine Geodaten.
+Der Data Manager ähnelt in seiner Funktionalität dem :ref:`digitizer_de`. Der Data Manager speichert allerdings nur Sachdaten und keine Geodaten.
 
 Der Data Manager kann zur Pflege von Referenztabllen verwendet werden, beispielsweise einer Tabelle mit Kontaktinformationen.
 
@@ -12,7 +12,7 @@ Setup
 -----
 
 Der Data Manager benötigt einen Zugriff auf die Datenbank, in der die zu editierenden Tabellen liegen. Sie müssen dazu einen Datenbankzugriff konfigurieren.
-Mehr zu diesem Thema finden Sie unter `Konfiguration der Datenbank <../../customization/yaml.html>`_.
+Mehr zu diesem Thema finden Sie unter :ref:`Konfiguration der Datenbank <yaml_de>`.
 
 Konfigurationsbeispiel
 ----------------------

--- a/de/functions/editing/digitizer/digitizer_configuration.rst
+++ b/de/functions/editing/digitizer/digitizer_configuration.rst
@@ -14,7 +14,7 @@ Das Element kann nur in der Sidepane eingebettet werden.
 * **Schemes:** YAML-Definition für das Element "digitizer"
 
 Der Digitizer benötigt einen Zugriff auf die Datenbank, in der die zu editierenden Tabellen liegen. Sie müssen dazu einen Datenbankzugriff konfigurieren.
-Mehr zu diesem Thema finden Sie unter `Konfiguration der Datenbank <../../../customization/yaml.html>`_.
+Mehr zu diesem Thema finden Sie unter :ref:`yaml_de`.
 
 Die Definition des Digitizers wird in einer YAML-Syntax durchgeführt. Hier definieren Sie die Datenbankverbindung, die editierbaren Felder, das Formular für die Anzeige und andere Verhaltensweisen.
 Bei fehlerhaften Angaben zur Datenbank, Feldern und Formularfehler erscheinen Fehlermeldungen. Über den normalen Aufruf und app.php kommt eine allgemeine Fehlermeldung.

--- a/de/functions/editing/sketch.rst
+++ b/de/functions/editing/sketch.rst
@@ -4,7 +4,7 @@ Skizzen (Sketch)
 ****************
 
 Mit diesem Element können temporär verfügbare Objekte in der Karte erstellt werden. Diese werden nicht in einer Datenbank gespeichert und gehen beim browsergesteuerten Aktualisieren oder Schließen der Anwendung verloren.
-Erstellte Skizzen werden im `Bildexport <../export/imageexport.html>`_ und `Druck <../export/printclient.html>`_ ausgegeben.
+Erstellte Skizzen werden im :ref:`imageexport_de` und :ref:`printclient_de` ausgegeben.
 
 Mit Skizzen können folgende Geometrietypen erstellt werden:
 

--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -232,7 +232,7 @@ Ein gruppenabhängiger Druck könnte bei einer Gruppe namens "Gruppe 1" wie folg
 .. image:: ../../../figures/de/print_client_example_groups.png
      :width: 100%
 
-Zur Nutzung dieser Funktion müssen Gruppen mit Benutzern erstellt und den Anwendungen die jeweiligen Gruppen zugewiesen werden. Weitere Informationen zur Funktionsweise der Gruppen- und Benutzerverwaltung stehen im :ref:`quickstart_de`.
+Zur Nutzung dieser Funktion müssen Gruppen mit Benutzern erstellt und den Anwendungen die jeweiligen Gruppen zugewiesen werden. Weitere Informationen zur Funktionsweise der Gruppen- und Benutzerverwaltung stehen im :ref:`Mapbender Schnellstart <quickstart_de>`.
 
 *Dynamisches Bild*
 ------------------

--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -232,7 +232,7 @@ Ein gruppenabhängiger Druck könnte bei einer Gruppe namens "Gruppe 1" wie folg
 .. image:: ../../../figures/de/print_client_example_groups.png
      :width: 100%
 
-Zur Nutzung dieser Funktion müssen Gruppen mit Benutzern erstellt und den Anwendungen die jeweiligen Gruppen zugewiesen werden. Weitere Informationen zur Funktionsweise der Gruppen- und Benutzerverwaltung unter `Mapbender Quickstart <../../quickstart.html>`_.
+Zur Nutzung dieser Funktion müssen Gruppen mit Benutzern erstellt und den Anwendungen die jeweiligen Gruppen zugewiesen werden. Weitere Informationen zur Funktionsweise der Gruppen- und Benutzerverwaltung stehen im :ref:`quickstart_de`.
 
 *Dynamisches Bild*
 ------------------
@@ -387,7 +387,7 @@ Nach Initialisierung des Warteschleifendrucks stehen die folgenden Funktionen ü
     mapbender:print:queue:rerun
     mapbender:print:runJob
 
-Bemerkung: Zur Ausführung der Befehle muss sich der Benutzer im application-Verzeichnis befinden und app/console den jeweiligen Befehlen voranstellen, also bspw.: app/console mapbender:print:queue:clean. Zur genauen Vorgehensweise siehe die Informationen auf der Seite `app/console Befehle <../../customization/commands.html>`_.
+.. hint:: Bemerkung: Zur Ausführung der Befehle muss sich der Benutzer im application-Verzeichnis befinden und app/console den jeweiligen Befehlen voranstellen. Zur genauen Vorgehensweise siehe die Informationen auf der Seite :ref:`commands_de`.
 
 
 *Warteschleifendruck: Durchführung*

--- a/de/functions/export/printclient.rst
+++ b/de/functions/export/printclient.rst
@@ -352,6 +352,8 @@ Das gewünschte Gebiet kann auswählt werden und ein PDF erzeugt. Das PDF beinha
 Bemerkung: Die Flexibilität, den Druckrahmen zu verschieben, hindert den Anwender nicht daran, den Rahmen in einen Bereich zu verschieben, der nicht das ausgewählte Objekt enthält. Die ausgedruckte Objektinformation passt dann nicht zur Darstellung in der Karte.
 
 
+.. _queued_print_de:
+  
 Warteschleifendruck
 -------------------
 

--- a/de/functions/misc/about_dialog.rst
+++ b/de/functions/misc/about_dialog.rst
@@ -3,7 +3,7 @@
 Über-Mapbender-Dialog (About Dialog)
 ************************************
 
-Dieses Element erstellt einen `Button <button.html>`_, der einen Dialog mit der aktuellen Mapbender Version anzeigt. Der Button kann in die obere Werkzeugleiste und in die Fußzeile eingefügt werden.
+Dieses Element erstellt einen :ref:`button_de`, der einen Dialog mit der aktuellen Mapbender Version anzeigt. Der Button kann in die obere Werkzeugleiste und in die Fußzeile eingefügt werden.
 
 .. image:: ../../../figures/de/about_dialog.png
      :scale: 80

--- a/de/functions/misc/button.rst
+++ b/de/functions/misc/button.rst
@@ -3,7 +3,7 @@
 Button
 ******
 
-Dieses Element stellt ein Button-Modul bereit. Einige Elemente wie die `Legende <../basic/legend.html>`_, `Layertree (Layerbaum) <../basic/layertree.html>`_, `FeatureInfo (Infoabfrage) <../basic/feature_info.html>`_, `Linien- und Flächenberechnung <../basic/ruler.html>`_ und der `Druck <../export/printclient.html>`_ benötigen einen Button, um einen Dialog anzuzeigen oder um aktiviert zu werden, wenn das Element in den Kartenbereich oder die Fußleiste eingebunden wurde.
+Dieses Element stellt ein Button-Modul bereit. Einige Elemente wie die :ref:`legend_de`, :ref:`layertree_de`, :ref:`feature_info_de`, :ref:`ruler_de` und der :ref:`printclient_de` benötigen einen Button, um einen Dialog anzuzeigen oder um aktiviert zu werden, wenn das Element in den Kartenbereich oder die Fußleiste eingebunden wurde.
 
 Buttons können optional gruppiert werden, sodass nur ein Button in der Gruppe aktiviert ist. Dies wird im Gruppen-Parameter eingestellt.
 Es kann außerdem ein Button definiert werden, der sich auf eine Webseite oder ein Script bezieht und bei Aktivierung zu diesem weiterleitet. Bei dem Parameter *Target* stehen nur Funktionen zur Auswahl, die vorher in der Anwendung unter dem Reiter *Layouts* entweder in den Kartenbereich oder die Fußleiste eingebunden wurden.
@@ -46,7 +46,7 @@ Buttons können für Features eingebunden werden, die vorher im Kartenbereich ko
 Button für die Legende
 -----------------------
 
-Für Karten sind Legenden sehr hilfreich, da sich so die Betrachter der Karte über den Inhalt informieren können. Die Legende ist in diesem Anwendungsbeispiel im Kartenbereich eingebunden. Wie eine Legende konfiguriert wird, wird in der Dokumentation unter `Legende <../basic/legend.html>`_ beschrieben.
+Für Karten sind Legenden sehr hilfreich, da sich so die Betrachter der Karte über den Inhalt informieren können. Die Legende ist in diesem Anwendungsbeispiel im Kartenbereich eingebunden. Wie eine Legende konfiguriert wird, wird in der Dokumentation unter :ref:`legend_de` beschrieben.
 Der Button für eine Legende wird wie folgt eingebunden:
 
 Zuerst muss über das ``+`` - Zeichen in der Anwendung (unter Layouts, Obere Werkzeugleiste) das Element Button ausgewählt werden.
@@ -95,7 +95,7 @@ Der Button wird, wie schon der Legendenbutton, über das ``+`` - Zeichen in der 
      
 Im Anwendungsbeispiel ist die Bezeichnung (*Title*) des Buttons "Linienmessung". Als *Target* wird das vorher im Kartenbereich erstellte Element "line" eingebunden. Um die Gruppierung mit der Flächenmessung möglich zu machen, wird im Feld *Group* ein Gruppenname vergeben. Hier lautet die Bezeichnung der Gruppe "messen". Dieser Gruppenname wird analog auch bei dem Button für die Flächenmessung eingetragen. Der Text "Linien messen" wird beim Platzieren der Maus auf dem Button angezeigt (*Tooltip*). Als *Icon* wird "Line ruler" gewählt.
 
-Das Element "line" wurde mithilfe der Funktion Linien-/Flächenmessung erstellt und als Linienmessung konfiguriert. Wie das Element Linien-/Flächenmessung konfiguriert wird, wird in der Dokumentation unter `Linien-/Flächenmessung <../basic/ruler.html>`_ beschrieben.
+Das Element "line" wurde mithilfe der Funktion Linien-/Flächenmessung erstellt und als Linienmessung konfiguriert. Wie das Element Linien-/Flächenmessung konfiguriert wird, wird in der Dokumentation unter :ref:`ruler_de` beschrieben.
 
 Der Button für die Flächenmessung wird analog eingebunden. Der Dialog der Konfiguration des Buttons sieht im Konfigurationsbeispiel wie folgt aus:
 

--- a/de/functions/misc/dimensions_handler.rst
+++ b/de/functions/misc/dimensions_handler.rst
@@ -44,7 +44,7 @@ Es bestehen zwei Möglichkeiten, die Zeitangabe in der Anwendung zu steuern. Zum
 Schieberegler im Kontextmenü
 ----------------------------
 
-Die Zeitachse kann über den Ebenenbaum als Option in das Kontextmenü des Layers im integriert werden. Dazu muss die "Dimension" Option in dem `Ebenenbaum <../basic/layertree.html>`_, aktiviert werden. 
+Die Zeitachse kann über den Ebenenbaum als Option in das Kontextmenü des Layers im integriert werden. Dazu muss die Option "Dimension" im :ref:`layertree_de` aktiviert werden. 
 
 .. image:: ../../../figures/de/wmst_layertree.png
      :scale: 80

--- a/de/functions/misc/wms_loader.rst
+++ b/de/functions/misc/wms_loader.rst
@@ -41,7 +41,7 @@ Diese Vorlage kann genutzt werden, um das Element in einer YAML-Anwendung einzub
 Hinzufügen eines WMS über einen definierten Link
 ================================================
 
-Mapbender kann einen WMS über einen definierten Link hinzufügen, z. B. über :ref:`die Informationsabfrage<feature_info_de>` oder über Suchergebnisse. Der Link sollte folgendermaßen aussehen:
+Mapbender kann einen WMS über einen definierten Link hinzufügen, z. B. über :ref:`feature_info_de` oder über Suchergebnisse. Der Link sollte folgendermaßen aussehen:
 
 .. code-block:: html
 

--- a/de/installation/installation_configuration.rst
+++ b/de/installation/installation_configuration.rst
@@ -118,8 +118,9 @@ Konfigurationsdateien
 
 Die Konfigurationsdateien liegen unter **app/config**. 
 
-Mehr Informationen dazu finden Sie im Kapitel : :ref:`yaml_de`.
+Mehr Informationen dazu finden Sie im Kapitel: :ref:`yaml_de`.
 
+.. _app_cache_de:
 
 Produktions- und Entwicklungsumgebung und Caches: app.php und app_dev.php
 -------------------------------------------------------------------------

--- a/de/installation/installation_symfony.rst
+++ b/de/installation/installation_symfony.rst
@@ -11,8 +11,8 @@ Das ermöglicht Ihnen einen schnellen Test von Mapbender, ohne eine Integration 
  
 In dieser Anleitung wird die im Installationspaket mitgelieferte SQLite-Datenbank verwendet.
 
-* Bitte prüfen Sie die Systemvoraussetzungen in der Installationsanleitung `Linux <installation_ubuntu.html>`_ bzw. `Windows <installation_windows.html>`_ 
-* Laden Sie die aktuellen Mapbender-Version herunter https://mapbender.org/builds/
+* Bitte prüfen Sie die Systemvoraussetzungen unter :ref:`Linux <installation_ubuntu_de>` bzw. :ref:`Windows <installation_windows_de>`.
+* Laden Sie die aktuellen Mapbender-Version herunter https://mapbender.org/builds/.
 * Entpacken in ein beliebiges Verzeichnis.
 * Starten Sie den Symfony-eigenen Webserver.
 

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -4,7 +4,7 @@ Installation auf Ubuntu/Debian
 ##############################
 
 Die mitgelieferte SQLite Datenbank ist für Testinstallationen geeignet. In dieser Datenbank befinden sich bereits vorkonfigurierte Demoanwendungen (die Datenbank liegt unter **<mapbender>/app/db/demo.sqlite**).
-Eine Anleitung für eine Testinstallation auf Basis des Symfony Webservers finden Sie unter `Installation auf dem Symfony eigenen Webserver <installation_symfony.html>`_.
+Eine Anleitung für eine Testinstallation auf Basis des Symfony Webservers finden Sie unter :ref:`installation_symfony_de`.
 
 .. hint:: Für den Produktiveinsatz wird PostgreSQL empfohlen. Weitere Installationshinweise finden Sie im Kapitel `Optional > Mapbender Einrichtung auf PostgreSQL <#optional>`_.
 
@@ -30,7 +30,7 @@ Installation der benötigten PHP-Extensions:
 
     sudo apt install php-gd php-curl php-cli php-xml php-sqlite3 sqlite3 php-apcu php-intl openssl php-zip php-mbstring php-bz2
 
-* Bitte prüfen Sie die Mapbender FAQ-Seite für weitere PHP-Einstellungen:  `FAQ <../faq.html>`_. 
+* Bitte prüfen Sie die :ref:`faq_de` für weitere PHP-Einstellungen. 
 
 
 Entpacken und im Webserver registrieren
@@ -105,7 +105,7 @@ Zur Überprüfung der Konfiguration dient der folgende Befehl:
 .. hint:: Bitte beachten Sie, dass der Befehl mapbender:config:check die PHP-CLI Version nutzt. Die Einstellungen der CLI-Version können sich von denen der Webserver PHP-Version unterscheiden. Nutzen Sie beispielsweise php -r 'phpinfo();' zur Ausgabe der PHP-Webserver Einstellungen.
 
 Glückwunsch! Mapbender wurde erfolgreich installiert.
-Informationen zu den ersten Schritten mit Mapbender finden sich unter:  `Mapbender Quickstart Dokument <../quickstart.html>`_.
+Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`quickstart_de`.
 
 
 Optional

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -105,7 +105,7 @@ Zur Überprüfung der Konfiguration dient der folgende Befehl:
 .. hint:: Bitte beachten Sie, dass der Befehl mapbender:config:check die PHP-CLI Version nutzt. Die Einstellungen der CLI-Version können sich von denen der Webserver PHP-Version unterscheiden. Nutzen Sie beispielsweise php -r 'phpinfo();' zur Ausgabe der PHP-Webserver Einstellungen.
 
 Glückwunsch! Mapbender wurde erfolgreich installiert.
-Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`quickstart_de`.
+Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`Mapbender Schnellstart <quickstart_de>`.
 
 
 Optional

--- a/de/installation/installation_update.rst
+++ b/de/installation/installation_update.rst
@@ -13,12 +13,12 @@ Um Mapbender zu aktualisieren, müssen Sie die folgenden Schritte durchführen:
 * Übernahme Ihrer Screenshots: Kopieren Sie die Dateien Ihrer alten Mapbender Version von mapbender/web/uploads/ in das mapbender/web/uploads Verzeichnis Ihrer neuen Mapbender Version
 * Wenn Sie Ihre eigenen Templates verwenden sollten, müssen Sie diese mit denen der neuen Version vergleichen (kam es zu Änderungen?)
 * Importieren Sie die Demo-Anwendungen (über den Befehl bin/composer run reimport-example-apps oder über die Web-Administration), um sich den neusten Stand der Entwicklungen anzuschauen
-* Unter https://doc.mapbender.org/de/installation/installation_ubuntu.html im Bereich **Entpacken und im Webserver registrieren** ist beschrieben, wie die Konfigurationsdatei für den Apache Alias aussehen sollte
+* Unter :ref:`installation_ubuntu_de` im Bereich **Entpacken und im Webserver registrieren** ist beschrieben, wie die Konfigurationsdatei für den Apache Alias aussehen sollte
 * Das war's auch schon! Schauen Sie sich Ihre neue Mapbender Version an.
 
 .. hint::
     
-    Folgen Sie bitte zusätzlich den Migrationshinweisen für bestimmte Versionen unter https://doc.mapbender.org/en/installation/migration.html.
+    Folgen Sie bitte zusätzlich den :ref:`Migrationshinweisen für bestimmte Versionen<migration>`.
 
 
 Aktualisierungsbeispiel für Linux

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -205,7 +205,7 @@ Zur Überprüfung der Konfiguration dient der folgende Befehl:
 
 .. hint:: Bitte beachten Sie, dass der Befehl mapbender:config:check die PHP-CLI Version nutzt. Die Einstellungen der CLI-Version können sich von denen der Webserver PHP-Version unterscheiden. Nutzen Sie beispielsweise php -r 'phpinfo();' zur Ausgabe der PHP-Webserver Einstellungen.
 
-Weitere Informationen dazu finden Sie unter: https://doc.mapbender.org/de/customization/commands.html#app-console-mapbender-config-check
+Weitere Informationen dazu finden Sie unter :ref:`mapbender_config_check_de`.
 
 Glückwunsch! Mapbender wurde erfolgreich installiert.
 Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`quickstart_de`.

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -208,4 +208,4 @@ Zur Überprüfung der Konfiguration dient der folgende Befehl:
 Weitere Informationen dazu finden Sie unter :ref:`mapbender_config_check_de`.
 
 Glückwunsch! Mapbender wurde erfolgreich installiert.
-Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`quickstart_de`.
+Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`Mapbender Schnellstart <quickstart_de>`.

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -62,7 +62,7 @@ Konfiguration PHP
     extension=php_zip.dll
     extension=php_bz2.dll
 
-* Bitte prüfen Sie die Mapbender FAQ-Seite für weitere PHP-Einstellungen:  `FAQ <../faq.html>`_. 
+* Bitte prüfen Sie die :ref:`faq_de` für weitere PHP-Einstellungen. 
 
 
 Mapbender entpacken und im Webserver registrieren
@@ -186,9 +186,6 @@ Der erste Start
 
 Die Mapbender Installation kann unter **http://[hostname]/mapbender/** aufgerufen werden.
 
-Weitere Schritte unter:  `Mapbender Quickstart Dokument <../quickstart.html>`_.
-
-
 
 **Überprüfung**
 
@@ -211,4 +208,4 @@ Zur Überprüfung der Konfiguration dient der folgende Befehl:
 Weitere Informationen dazu finden Sie unter: https://doc.mapbender.org/de/customization/commands.html#app-console-mapbender-config-check
 
 Glückwunsch! Mapbender wurde erfolgreich installiert.
-Informationen zu den ersten Schritten mit Mapbender finden sich unter:  `Mapbender Quickstart Dokument <../quickstart.html>`_.
+Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`quickstart_de`.

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -245,8 +245,10 @@ Die Übersichtsseite bietet dem Nutzer folgende Funktionen:
 
   .. image:: ../figures/de/mapbender_sources.png
      :width: 100%
-     
-     
+
+
+.. _load_sources_de:
+
 Laden von Datenquellen
 ----------------------
 

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -66,13 +66,13 @@ Eine Mapbender Anwendung kann wie folgt aussehen:
 Installation
 ============
 
-Dieser Schnellstart erklärt die Mapbender-Grundlagen nach erfolgter Installation und bietet einen schnellen Einstieg in die Mapbender-Oberfläche. Hinweise zur Installation von Mapbender finden Sie unter `Installation <installation.html>`_.
+Dieser Schnellstart erklärt die Mapbender-Grundlagen nach erfolgter Installation und bietet einen schnellen Einstieg in die Mapbender-Oberfläche. Hinweise zur Installation von Mapbender finden Sie unter :ref:`installation_de`.
 
 
 1. Mapbender starten
 ====================
 
-#. Wählen Sie ``Mapbender`` aus dem Startmenü (sofern vorher eine solche browseröffnende Verknüpfung erstellt wurde) oder besuchen Sie http://localhost/mapbender/app.php (Adresse kann unter Umständen abweichen, je nachdem wie der Apache Alias in der Datei /etc/apache2/sites-available/mapbender.conf erstellt wurde, siehe auch `Installation <installation.html>`_).
+#. Wählen Sie ``Mapbender`` aus dem Startmenü (sofern vorher eine solche browseröffnende Verknüpfung erstellt wurde) oder besuchen Sie http://localhost/mapbender/app.php (Adresse kann unter Umständen abweichen, je nachdem wie der Apache Alias in der Datei /etc/apache2/sites-available/mapbender.conf erstellt wurde, siehe auch :ref:`installation_de`).
 
 #. Das Mapbender-Backend sollte anschließend im Browserfenster erscheinen.
 
@@ -132,7 +132,7 @@ In der Anwendungsübersicht finden Sie eine Liste mit allen verfügbaren Anwendu
 
 Es gibt drei verschiedene Möglichkeiten, durch die neue Anwendungen erstellt werden können:
 
-Einerseits besteht die Option, diese aus bereits vorhandenen Anwendungen zu erstellen. Dies erfolgt über einen Klick auf den |mapbender-button-copy| Button in der Anwendungsübersicht. Die Applikation erhält dabei den gleichen Titel und URL-Titel zuzüglich dem Zusatz *"_imp"*. Alle zuvor definierten Elemente und Konfigurationen werden ebenfalls übernommen. Eine weitere Möglichkeit ist der Import einer Anwendung. Zusätzliche Informationen hierzu finden sich auf der Seite  `YAML Konfiguration <./customization/yaml.html>`_.
+Einerseits besteht die Option, diese aus bereits vorhandenen Anwendungen zu erstellen. Dies erfolgt über einen Klick auf den |mapbender-button-copy| Button in der Anwendungsübersicht. Die Applikation erhält dabei den gleichen Titel und URL-Titel zuzüglich dem Zusatz *"_imp"*. Alle zuvor definierten Elemente und Konfigurationen werden ebenfalls übernommen. Eine weitere Möglichkeit ist der Import einer Anwendung. Zusätzliche Informationen hierzu finden sich unter :ref:`yaml_de`.
 
 Es können außerdem komplett neue Anwendungen über das Backend definiert werden. Die einzelnen Arbeitsschritte hierfür werden im Folgenden näher erläutert:
 
@@ -140,7 +140,7 @@ Es können außerdem komplett neue Anwendungen über das Backend definiert werde
 
 #. Wählen Sie anschließend eine Vorlage für die Anwendung. Diese bestimmt den Aufbau der Anwendung. Zur Auswahl stehen: Fullscreen, Fullscreen alternative, Mapbender Mobile template. Es ist ebenfalls möglich, eigene Vorlagen anzulegen und neuen Anwendungen zuzuordnen.
 
-.. tip:: Beachten Sie, dass Layout-, Icon- und Farbanpassungen online über den CSS_Editor oder in css- und twig-Dateien erfolgen. Lesen Sie dazu die Dokumentation unter `Wie werden eigene Vorlagen (templates) erzeugt? <customization/templates.html>`_.
+.. tip:: Beachten Sie, dass Layout-, Icon- und Farbanpassungen online über den CSS_Editor oder in css- und twig-Dateien erfolgen. Lesen Sie dazu die Dokumentation unter :ref:`templates_de`.
 
 #. Geben Sie einen Titel, einen URL-Titel und ggf. eine Beschreibung für die Anwendung an. Titel und URL-Titel können identisch sein. Letzterer muss sich nach den Standards der festgelegten URL-Syntax richten.
 
@@ -148,7 +148,7 @@ Es können außerdem komplett neue Anwendungen über das Backend definiert werde
 
 #. Wählen Sie unter *"Karten-Engine"* die von Ihnen bevorzugte OpenLayers-Version aus.
 
-#. Setzen Sie ein Häkchen bei *"Kartenzustand merken"*, um bestimmte Kartenparameter und -einstellungen persistent zu machen. Weitere Informationen finden Sie auf der Seite zu den `Share-Elementen <./functions/share.html>`_.
+#. Setzen Sie ein Häkchen bei *"Kartenzustand merken"*, um bestimmte Kartenparameter und -einstellungen persistent zu machen. Weitere Informationen finden Sie unter :ref:`share_de`.
 
 #. Klicken Sie *"Speichern"*, um die Anwendung zu erzeugen. Nach der Erstellung können Sie Elemente (z.B. Kartenelement, Navigation, Legende) und Dienste hinzufügen.
 
@@ -181,7 +181,7 @@ Jetzt sollten sie eine Idee davon haben, wie einfach es ist, eine Mapbender-Anwe
   .. image:: ../figures/de/mapbender_application_add_element.png
      :width: 100%
 
-Im Folgenden finden Sie eine vollständige Liste aller Elemente inklusive ihrer Funktion. Detaillierte Informationen können Sie in den jeweiligen Kapiteln der `Mapbender Dokumentation <index.html>`_ nachlesen.
+Im Folgenden finden Sie eine vollständige Liste aller Elemente inklusive ihrer Funktion. Detaillierte Informationen können Sie in den jeweiligen Kapiteln der :ref:`Mapbender Dokumentation <welcome_de>` nachlesen.
 
 * Aktivitätsanzeige: zeigt die HTTP-Aktivität an
 * Ansichtsverwaltung: speichert Kartenzustände zum späteren Abruf
@@ -318,7 +318,7 @@ Sie können Dienste für Ihre Anwendung konfigurieren. Vielleicht möchten Sie s
 
 **Dimensionen:**
 
-Diese Funktion ist für WMS-Dienste mit einer zeitlichen Dimension von Relevanz. Weitere Informationen hierzu finden Sie auf der Seite des `Dimensions Handler <./functions/misc/dimensions_handler.html>`_.
+Diese Funktion ist für WMS-Dienste mit einer zeitlichen Dimension von Relevanz. Weitere Informationen hierzu finden Sie unter :ref:`Dimensions Handler <dimensions_handler_de>`.
 
 **Vendor Specific Parameter:**
 

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -233,7 +233,7 @@ Versuchen Sie es selbst
 Datenquellen (Sources) verwenden
 ================================
 
-In Mapbender können Dienste vom Typ OGC WMS und OGC WMTS / TMS eingeladen werden. Durch einen Klick auf ``Datenquellen`` kann zu einer Übersicht mit allen hinzugefügten Diensten navigiert werden. Diese ist wiederum in eine Liste mit allen Datenquellen sowie den freien Instanzen untergliedert. Mehr Informationen zu privaten und freien Instanzen finden sich auf der Seite :ref:`Layerset <layerset_de>` .
+In Mapbender können Dienste vom Typ OGC WMS und OGC WMTS / TMS eingeladen werden. Durch einen Klick auf ``Datenquellen`` kann zu einer Übersicht mit allen hinzugefügten Diensten navigiert werden. Diese ist wiederum in eine Liste mit allen Datenquellen sowie den freien Instanzen untergliedert. Mehr Informationen zu privaten und freien Instanzen finden sich unter :ref:`layerset_de`.
 
 Die Übersichtsseite bietet dem Nutzer folgende Funktionen:
 

--- a/de/versions.rst
+++ b/de/versions.rst
@@ -284,7 +284,7 @@ Release Datum: 13.07.2018
 
 **Neue Funktionen:**
 
-* QGIS Server Layerreihenfolgende, dokumentiert unter der Rubrik layerset_de
+* QGIS Server Layerreihenfolgende, dokumentiert unter der Rubrik :ref:`layerset_de`
 * Neues Element: :ref:`coordinate_utility_de`
 * Mouse-Over im SearchRouter
 * GPS Button im POI

--- a/en/backend/FOM/security.rst
+++ b/en/backend/FOM/security.rst
@@ -5,15 +5,15 @@ Security Concepts
 
 Security as provided by the FOMUserBundle is anchored on these base concepts:
 
-- :doc:`Users <users>`
-- :doc:`Roles and Groups <roles_groups>`
-- :doc:`ACL <acl>`
+- :ref:`users`
+- :ref:`roles_groups`
+- :ref:`acl`
 
 
 Rights management
 *****************
 
-Mapbender provides different rights. They refer to the :doc:`Access Control Lists (ACL) <acl>`.
+Mapbender provides different rights. They refer to the :ref:`acl`.
 
 * view - Whether someone is allowed to view the object.
 * edit - Whether someone is allowed to make changes to the object.

--- a/en/backend/applications/layerset.rst
+++ b/en/backend/applications/layerset.rst
@@ -1,5 +1,8 @@
 .. _layerset:
 
+Layerset
+********
+
  .. |mapbender-button-add| image:: ../../../figures/mapbender_button_add.png
 
  .. |mapbender-button-checkbox| image:: ../../../figures/mapbender_button_checkbox.png
@@ -9,11 +12,7 @@
  .. |mapbender-button-delete| image:: ../../../figures/mapbender_button_delete.png
 
  .. |mapbender-button-publish| image:: ../../../figures/mapbender_button_publish.png
-
-
-Layerset
-********
-
+     
 Layersets are logical containers that can contain one or more layerset-instances (WMS services). In the demo applications two layersets are defined: Layerset "main" for the main map and layerset "overview" for the overview map. The names of the layersets can be freely chosen. Moreover, more than one layerset can be chosen in the map element. Layertree shows the layerset name when thematic layers is activated.
 
 Layerset Overview Page
@@ -57,13 +56,13 @@ The screenshot above shows the `bound instance <#shared-and-bound-instances>`_ `
 
 - **Format:** The image format which is used to get the map images for the application via the GetMap request. For raster data and aerial imagery the JPG format is recommended, in case of street maps the PNG format should be preferred. If you are in doubt use PNG.
 
-- **Infoformat:** The format which is used for the GetFeatureInfo requests to the WMS. If you are in doubt use text/html or an analog HTML format that can be used in the dialog of the :ref:`FeatureInfo <feature_info>` element. Another possibility is text/plain.
+- **Infoformat:** The format which is used for the GetFeatureInfo requests to the WMS. If you are in doubt use text/html or an analog HTML format that can be used in the dialog of the :ref:`feature_info` element. Another possibility is text/plain.
 
 - **Exceptionformat:** The format for error-messages that are returned by the WMS service.
 
 **The properties for the application**
 
-- **Opacity:** Choose the Opacity in percent. This value can be changed by the user in the  :ref:`Layertree <layertree>`, if it's made available in the corresponding menu.
+- **Opacity:** Choose the Opacity in percent. This value can be changed by the user in the  :ref:`layertree`, if it's made available in the corresponding menu.
 
 - **Tile buffer:** This parameter applies to services that are tiled and specifies whether to retrieve more surrounding tiles. With that they are already downloaded and visible during a pan movement. The higher the value, the more surrounding tiles are retrieved. Default: 0.
 
@@ -193,7 +192,7 @@ Tiling, map-size and performance
 
 The "Tiled" parameter is used to request the map image in individual tiles rather than as a whole image. This should be turned on in general, if you use `Mapproxy <https://mapproxy.de/>`_ to provide a tiled service. But it also makes sense for normal, un-tiled services, since the perceived waiting time for the user gets lower: The map image appears, although not all tiles have been retrieved yet.
 
-Keep in mind that the number of requests to a WMS increases rapidly: Depending on the screen resolution and the set tile size in the :ref:`Map element <map>` many requests are sent to the server. Although the returned images are not very large (usually you set tile sizes of 256x256 or 512x512 pixels), they are large in numbers. This is also valid in regard to the **tile buffer**. So it is a trade-off and a case-by-case distinction how to address the service. The performance can also be increased by setting the scales of a layer in the layerset-instance.
+Keep in mind that the number of requests to a WMS increases rapidly: Depending on the screen resolution and the set tile size in the :ref:`map`, many requests are sent to the server. Although the returned images are not very large (usually you set tile sizes of 256x256 or 512x512 pixels), they are large in numbers. This is also valid in regard to the **tile buffer**. So it is a trade-off and a case-by-case distinction how to address the service. The performance can also be increased by setting the scales of a layer in the layerset-instance.
 
 There are also some WMS services that only support a maximum image size that cannot be used with the high resolutions request that Mapbender can call. The Fullscreen template can be sized to the maximum screen width and the requested map image is then approximately the width and height of the visible browser window.
 

--- a/en/backend/sources.rst
+++ b/en/backend/sources.rst
@@ -5,7 +5,7 @@ Sources
 
 With Sources, you can register OGC WMS and OGC WMTS/TMS services in version 1.1.1 and 1.3.0 in Mapbender.
 
-Further information about the registration process of services and their usage in applications is available in the `Quickstart document <../../quickstart.html#load-sources>`_.
+Further information about the registration process of services and their usage in applications is available in the Quickstart chapter :ref:`load_sources`.
 
 
 Load sources

--- a/en/backend/sources.rst
+++ b/en/backend/sources.rst
@@ -1,8 +1,5 @@
 .. _sources:
 
-  .. |mapbender-button-add| image:: ../../figures/mapbender_button_add.png
-  .. |mapbender-button-update| image:: ../../figures/mapbender_button_update.png
-
 Sources
 =======
 
@@ -15,6 +12,8 @@ Load sources
 ------------
 
 .. tip:: It is important to check the service before it is registered in Mapbender. To do that, open the getCapabilities-Request (see example in Service URL) in your browser.
+
+  .. |mapbender-button-add| image:: ../../figures/mapbender_button_add.png
 
 To register a service, click on |mapbender-button-add| **Add source**:
 
@@ -65,6 +64,9 @@ In the metadata dialog of a specific service, it is also possible to click on th
 
 Updating sources
 ----------------
+
+  .. |mapbender-button-update| image:: ../../figures/mapbender_button_update.png
+
 To update a source in the backend, you first need to navigate to the ``Sources`` backend list.
 On this page, look for the layer you wish to update via scrolling or use the search box.
 After you've found it, click on its |mapbender-button-update| **Refresh** button.

--- a/en/customization/commands.rst
+++ b/en/customization/commands.rst
@@ -190,7 +190,7 @@ The queued print is disabled by default because it requires some external integr
 
 	mapbender.print.queueable: true
 
-Read more about the general characteristics of queued print at https://doc.mapbender.org/en/functions/export/printclient.html#queued-print or https://github.com/mapbender/mapbender/pull/1070
+Read more about the general characteristics of :ref:`queued_print`. Also here: https://github.com/mapbender/mapbender/pull/1070
 
 The print assistant is then updated in the backend of Mapbender and two new lines appear: mode and queue. 
 Mode is set to "queue" and queue is set to "global", if the print jobs are expected to be accessible to all colleagues. 
@@ -593,7 +593,9 @@ Command to update the host name in the source URLs. Like this it is not necessar
 	4 sources unchanged
 	14 urls unchanged
     
-    
+
+.. _mapbender_config_check:
+
 app/console mapbender:config:check 
 **********************************
 

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -122,7 +122,7 @@ Configuration example:
     locale:            en    
     secret:            ThisTokenIsNotSoSecretChangeIt
 
-More information: https://doc.mapbender.org/en/architecture/translation.html
+More information in :ref:`translation`.
 
 
 Logo
@@ -332,7 +332,7 @@ Footer
     * © OpenStreetMap contributors (Button)
     * HTML-powered by Mapbender (HTML)
 
-Detailed descriptions of the functions: https://doc.mapbender.org/de/functions.html
+Detailed descriptions of the :ref:`functions`
 
 
 
@@ -350,7 +350,7 @@ Sidepane
 Map area
     Instead of 'Scale display' and 'POI', the function 'Coordinates utility' is integrated.
 
-Detailed descriptions of the functions: https://doc.mapbender.org/de/functions.html
+Detailed descriptions of the :ref:`functions`
 
 
 

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -217,7 +217,7 @@ Important: Every database defined in parameters.yml needs to have a placeholder 
                 driver:    "%database_driver%"              # More information below the code
                 host:      "%database_host%"                # Database host on which the database runs. Either name of the host (e.g. localhost) or IP address (e.g. 127.0.0.1).
                 port:      "%database_port%"                # Port, the database listens to (e.g. 5432 for PostgreSQL).
-                dbname:    "%database_name%"                # Name of the database (e.g. mapbender). Create a database with the command ``doctrine:database:create`` bzw. ``doctrine:schema:create``. More information:  `Installation<../installation.html>`_.
+                dbname:    "%database_name%"                # Name of the database (e.g. mapbender). Create a database with the command ``doctrine:database:create`` bzw. ``doctrine:schema:create``.
                 path:      "%database_path%"                # %database_path%, path to the file of the SQLite database. If you don't use a SQ-lite database, write (~) or ``null``.
                 user:      "%database_user%"                # User name for database connection.
                 password:  "%database_password%"            # Password.

--- a/en/development/introduction.rst
+++ b/en/development/introduction.rst
@@ -25,7 +25,7 @@ to Mapbender:
 Installation
 ************
 
-The installation procedure from Git is described in the chapter `Git-based installation <../installation/installation_git.html>`_.
+The installation procedure from Git is described under :ref:`installation_git`.
 
 
 Getting Help

--- a/en/faq.rst
+++ b/en/faq.rst
@@ -13,7 +13,7 @@ Q: What purpose do app.php and app_dev.php have?
 
 A: For productive use you'll use the app.php file. Only if you develop something (TWIG-files, CSS or JS-files) or for debugging, you'll open Mapbender with the app_dev.php in developer mode. This is because the developer mode provides more information and error messages. 
 
-For further information on the modes, please take a look at the chapter `Details of the configuration of Mapbender - Production- and Development environment and Caching: app.php and app_dev.php <installation/configuration.html#production-and-development-environment-and-caching-app-php-and-app-dev-php>`_.
+For further information on the modes, please take a look at the chapter :ref:`app_cache`.
 
 
 Cache
@@ -25,7 +25,7 @@ A: The cache is a small storage area, where Mapbender accesses frequently needed
 
 It is no problem to delete these directories. When you run Mapbender again, new files will be stored again in the cache directory.
 
-For further information on the cache, please take a look at the chapter `Details of the configuration of Mapbender - Production- and Development environment and Caching: app.php and app_dev.php <installation/configuration.html#production-and-development-environment-and-caching-app-php-and-app-dev-php>`_.
+For further information on the cache, please take a look at the chapter :ref:`app_cache`.
 
 
 Services and their usage in applications

--- a/en/faq.rst
+++ b/en/faq.rst
@@ -122,7 +122,7 @@ Adjust the height with this parameter and an individual value:
 Working with large WMS Services with many layers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Q: When I try to use a WMS Service with many layers (> 100) into an application, the configuration of the `Layerset-Instance <backend/applications/layerset.html>`_ only takes and presents an incorrect amount of layers. In addition, the wms instance cannot be saved. Why?
+Q: When I try to use a WMS Service with many layers (> 100) into an application, the configuration of the :ref:`layerset` only takes and presents an incorrect amount of layers. In addition, the wms instance cannot be saved. Why?
 
 A: To solve the problem, navigate to the php parameter `max-input_vars <https://php.net/manual/de/info.configuration.php#ini.max-input-vars>`_. It defines the number of possible input variables. The default value is 1000 (depending on the php version). 
 For a WMS with many layers, the number of input values is higher than the default value. You have to change the parameter to a higher value (e.g. 2000). 

--- a/en/functions/basic/coordinates_display.rst
+++ b/en/functions/basic/coordinates_display.rst
@@ -4,8 +4,7 @@ Coordinates Display
 *******************
 
 The coordinates display element shows your mouse position in map coordinates.
-The coordinates are dependent on the selected spatial reference system which may be changed in the
-`Spatial Reference System Selector <srs_selector.html>`_.
+The coordinates are dependent on the selected spatial reference system which may be changed in the :ref:`srs_selector`.
 
 The coordinates display for different coordinate systems looks like this:
 

--- a/en/functions/basic/feature_info.rst
+++ b/en/functions/basic/feature_info.rst
@@ -35,7 +35,7 @@ Configuration
 * **Opacity (%) of the hover color** Sets the opacity of the hover color.
 * **Stroke width (pixels) of the hover color** Sets the stroke width (in pixels) of the hover color.
 
-A button is also needed for complete frontend integration. Further information on how to configure a button: `Button <../misc/button.html>`_.
+A :ref:`button` is also needed for complete frontend integration.
 
 Layertree settings
 ------------------

--- a/en/functions/basic/layertree.rst
+++ b/en/functions/basic/layertree.rst
@@ -30,9 +30,9 @@ Functions
 
 Please also configure the elements below that are connected to the Layertree:
 
-* `Layersets <../../backend/applications/layerset.html>`_
-* `Map element <../basic/map.html>`_
-* `Sources <../../backend/sources.html>`_
+* :ref:`layerset`
+* :ref:`map`
+* :ref:`sources`
 
 
 Configuration
@@ -50,7 +50,7 @@ To use the different Layersets in our Layertree, various adjustments are necessa
 Layers are included in the application via the **Layerset** tab in the backend.
 
 The instances are the references to the individual WMS services. With the large ``+`` button, new Layersets can be created. New layers can be integrated in the application by adding registered instances into Layersets. In the example, the Layerset "overview" is used for displaying the overview map.
-For a detailed documentation on how the services can be integrated and registered correctly, please head to the documentation of `layersets <../../backend/applications/layerset.html>`_ and `sources <../../backend/sources.html>`_.
+For a detailed documentation on how the services can be integrated and registered correctly, please head over to the :ref:`layerset` and :ref:`sources` documentation..
 
 .. figure:: ../../../figures/mapbender_add_source_to_application.png
            :scale: 80
@@ -58,7 +58,7 @@ For a detailed documentation on how the services can be integrated and registere
 
            Configuration of various Layersets for integration into the Layertree.
 
-In order to let the newly integrated Layersets appear in the application, they must be specified in the `Map element <../basic/map.html>`_. 
+In order to let the newly integrated Layersets appear in the application, they must be specified in the :ref:`Map element <map>`. 
 Here, you define which Layersets you want to use in the map by checking the boxes in the list. For example, the Layerset "overview" is not displayed on the main map.
 In this step, you define the order in which the Layersets appear in your Layertree and the map. You can move the created Layersets from the list by drag & drop.
 
@@ -86,7 +86,7 @@ In the example, we defined one **Layerset** with one instance:
     * Instance OSM Demo Service https://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0
 
 The registered instance of the OSM  Demo Service is automatically included in Mapbender's installation. The WMS only has to be integrated into an existing Layerset. Switch to the tab Layersets. The following example uses the Layerset "World". 
-In case of difficulties with the integration, the `Layersets <../../backend/applications/layerset.html>`_ documentation provides useful information.
+In case of difficulties with the integration, :ref:`layerset` provides useful information.
 
 .. figure:: ../../../figures/layertree/layertree_configuration_layerset_simple_en.png
            :scale: 80
@@ -96,10 +96,10 @@ In case of difficulties with the integration, the `Layersets <../../backend/appl
 
 **Configuration of the map to display the Layerset**
 
-In the next step, we configure the `Map element <../basic/map.html>`_ to display the Layersets in the **Map**. To do this, you need to switch to the **Layouts** tab and edit the map element in the map area. 
+In the next step, we configure the :ref:`Map element <map>`  to display the Layersets in the **Map**. To do this, you need to switch to the **Layouts** tab and edit the map element in the map area. 
 It is important that you activate the checkbox next to the "World" Layerset so it appears in the application afterwards.
 
-If you have questions for further configuration, the `Map element <../basic/map.html>`_ documentation can help.
+If you have questions for further configuration, the :ref:`Map element <map>` documentation can help.
 
 
 .. figure:: ../../../figures/layertree/layertree_configuration_map_simple_en.png
@@ -130,7 +130,7 @@ Via the **Menu** a number of functions can be activated, which are then availabl
 * *Opacity* (change the opacity of a layer)
 * *Zoom to layer* (zoom to full layer extent)
 * *Metadata* (show the metadata of the layer)
-* *Dimension* (change the dimension, e.g. time or elevation of the Layer - read more about the `Dimensions handler <../misc/dimensions_handler.html>`_ )
+* *Dimension* (change the dimension, e.g. time or elevation of the Layer - read more about the :ref:`dimensions_handler` )
 
 .. figure:: ../../../figures/layertree/layertree_menu.png
            :scale: 80
@@ -184,7 +184,7 @@ In the example, we define two layersets with two instances each:
     * Instance OSM  Demo Service http://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0
     * Instance `GEBCO <https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_ 
 
-For the configuration of the layersets, the four services mentioned above were added as instances (For detailed information see above or in the documentation of the `Layersets <../../backend/applications/layerset.html>`_ and `Sources <../../backend/sources.html>`_).
+For the configuration of the layersets, the four services mentioned above were added as instances (For detailed information, see above or in the :ref:`layerset` and :ref:`sources` documentation).
 
 For this example, the above mentioned steps were performed to add the Layerset "World" **[2]** with the instance "osm". Now we add the instance "GEBCO" in this Layerset. 
 To use the thematic grouping, we create a new Layerset named "Project NRW" **[3]** and load the two instances "DTK50 NRW" and "Forest NRW" into our new Layerset "Project NRW".  
@@ -199,10 +199,10 @@ The Layerset should now contain three Layersets. The **Overview** [1] for the ov
 
 **Configuration of the map to display the Layerset**
 
-Now, we configure the `map element <../basic/map.html>`_  to display the Layersets in the map. To do this, we switch to the **Layouts** backend tab and edit the feature in the map area.
+Now, we configure the :ref:`Map element <map>` to display the Layersets in the map. To do this, we switch to the **Layouts** backend tab and edit the feature in the map area.
 It is now important that you set an active checkbox in the Layerset "World" AND Layerset "Project NRW", so that they both appear in the application.
 
-If you have questions regarding further configuration of the map, you can view its configuration in the `map element <../basic/map.html>`_.
+If you have questions regarding further configuration of the map, you can view its configuration in the :ref:`Map element <map>`.
 
 
 .. figure:: ../../../figures/layertree/layertree_configuration_map_komplex_en.png
@@ -216,7 +216,7 @@ If you have questions regarding further configuration of the map, you can view i
 The last step is the creation of the Layertree itself. In this example, we add the thematic Layertree to the sidepane.
 
 If the option **Thematic layer** is disabled, the Layertree ignores the configured Layersets and shows the individual instances without thematic structuring in the main level. However, we want to show the layers of our thematic Layersets, so we activate the function **Thematic layer**.
-Since we inserted both Layersets into the `map element <../basic/map.html>`_ of the application, they are now displayed under the **Themes**-area.
+Since we inserted both Layersets into the :ref:`Map element <map>` of the application, they are now displayed under the **Themes**-area.
 
 .. figure:: ../../../figures/layertree/layertree_configuration_2_en.png
            :scale: 80 

--- a/en/functions/basic/legend.rst
+++ b/en/functions/basic/legend.rst
@@ -21,7 +21,7 @@ Configuration
 * **Show layer title:** shows layer title (default: true)
 * **Show grouped layer title:** shows group title for grouped layers (default: true)
 
-The Legend element is integrated via a button or in the sidepane. If you look for configurational details for the button, head over to this page: `Button <../misc/button.html>`_.
+The Legend element is integrated via a :ref:`button` or in the sidepane.
 
 
 Configuration Examples
@@ -61,7 +61,7 @@ In this example, the following settings are chosen:
      :scale: 75
 
 In our example, the checkbox *Auto-open* is dismissed. Therefore, the legend opens only with a click on a button.
-This button has to be implemented into the toolbar section. For detailed instructions on buttons, see the Mapbender-Documentation page `Button <../misc/button.html>`_.
+This :ref:`button` has to be implemented into the toolbar section.
 
 The configuration of a button can look like this:
 

--- a/en/functions/basic/navigation_toolbar.rst
+++ b/en/functions/basic/navigation_toolbar.rst
@@ -41,7 +41,7 @@ If you set a tick at **Draggable**, then a small cross will appear next to the n
 
 **Rotation** enables changes of the map orientation. A click on the north arrow allows for a restoration of the original rotation.
 
-Users can zoom to their smallest scale by **Zoom to max extent**. This *Max Extent* can be set individually in the `map element <map.html>`_ of the The element must be integrated into the Map area.
+Users can zoom to their smallest scale by **Zoom to max extent**. This *Max Extent* can be set individually in the :ref:`map element <map>`. The element must be integrated into the Map area.
 
 .. image:: ../../../figures/navigationtoolbar_zoom_to_max.png
      :scale: 80

--- a/en/functions/basic/srs_selector.rst
+++ b/en/functions/basic/srs_selector.rst
@@ -3,7 +3,7 @@
 SRS Selector
 ************
 
-The spatial reference system selector changes the map's spatial reference system. The selectbox offers SRS that are defined within the `map element <map.html>`_.
+The spatial reference system selector changes the map's spatial reference system. The selectbox offers SRS that are defined within the :ref:`Map element <map>`.
 
 .. image:: ../../../figures/srs_selector.png
      :scale: 100

--- a/en/functions/editing/datamanager.rst
+++ b/en/functions/editing/datamanager.rst
@@ -3,7 +3,7 @@
 Data Manager
 ************
 
-The element Data Manager is similar to the `Digitizer <digitizer.html>`_. 
+The element Data Manager is similar to the :ref:`digitizer`. 
 However, Data Manager only works with nonspatial data, i. e. you can not create geometries.
 
 Data Manager can be used to maintain reference tables for example a table with contact information.
@@ -12,7 +12,7 @@ Setup
 -----
 
 The Data Manager needs access to a database where the editable tables are. You have to define a new database configuration to be able to connect with. 
-Read more about this at `database <../../../customization/yaml.html>`_.
+Read more about this under :ref:`yaml`.
 
 
 Configuration example

--- a/en/functions/editing/digitizer/digitizer_configuration.rst
+++ b/en/functions/editing/digitizer/digitizer_configuration.rst
@@ -14,7 +14,7 @@ You can only use the element in the sidepane.
 * **Schemes:** YAML-Definition of the element Digitizer
 
 The Ditigitzer needs access to a database where the editable tables are. You have to define a new database configuration to be able to connect with the geo database. 
-Read more about this at `database <../../../customization/yaml.html>`_.
+Read more about this under :ref:`yaml`.
 
 The definition of the Digitizer is done in YAML syntax in the textarea configuration at schemes. Here you define the database connection, the editable table, the form to display the table, the attribute form and other behavior.
 If errors occur in the database, fields or form, various error messages appear. Via the normal call and app.php comes a general error message.

--- a/en/functions/editing/sketch.rst
+++ b/en/functions/editing/sketch.rst
@@ -4,7 +4,7 @@ Sketches
 ********
 
 The Sketches element allows creating, editing and deleting temporary objects. Sketches are not saved within a database and will be lost after the browser window is refreshed or closed.
-Sketch geometries will be exported into `Image Export <../export/imageexport.html>`_ and `PrintClient <../export/printclient.html>`_.
+Sketch geometries will be exported into :ref:`imageexport` and :ref:`printclient`.
 
 The following geometry types can be sketched:
 

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -231,7 +231,7 @@ The print with a group named "Group 1" could look like this:
 .. image:: ../../../figures/print_client_example_groups.png
      :width: 100%
 
-To use this feature, it is required that groups exist. How to create groups and users is described in the Mapbender documentation in the :ref:`quickstart`.
+To use this feature, it is required that groups exist. How to create groups and users is described in the Mapbender documentation in the :ref:`Mapbender Quickstart <quickstart>`.
 
 The description of the group will be displayed in the field "dynamic_text" (e.g. copyright message).
 The element "dynamic_text" looks for a group description that is given in the first assigned group of the print. You can implement the dynamic text independently from the dynamic image. 

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -338,6 +338,8 @@ With click on the print button the print dialog opens and offers the print templ
 .. note:: The flexibility to move the print frame won‘t stop you from choosing a region that does not contain the feature that was selected. In this case, the feature information does not match to the features that are displayed.
 
 
+.. _queued_print:
+
 Queued Print
 ------------
 

--- a/en/functions/export/printclient.rst
+++ b/en/functions/export/printclient.rst
@@ -231,7 +231,7 @@ The print with a group named "Group 1" could look like this:
 .. image:: ../../../figures/print_client_example_groups.png
      :width: 100%
 
-To use this feature, it is required that groups exist. How to create groups and users is described in the Mapbender documentation in the `Mapbender Quickstart <../../quickstart.html>`_.
+To use this feature, it is required that groups exist. How to create groups and users is described in the Mapbender documentation in the :ref:`quickstart`.
 
 The description of the group will be displayed in the field "dynamic_text" (e.g. copyright message).
 The element "dynamic_text" looks for a group description that is given in the first assigned group of the print. You can implement the dynamic text independently from the dynamic image. 
@@ -375,7 +375,7 @@ After the setup, the queued print can be controlled with several bash commands, 
     mapbender:print:queue:rerun
     mapbender:print:runJob
 
-.. note:: To run the commands, open a terminal and head to the Mapbender application directory. Then, execute a command like this: 'app/console mapbender:print:queue:clean'. Detailed information on the commands:  `app/console commands <../../customization/commands.html>`_.
+.. note:: To run the commands, open a terminal and head to the Mapbender application directory. Find detailed information on the commands under :ref:`commands`.
 
 
 *Queued print: Usage*

--- a/en/functions/misc/about_dialog.rst
+++ b/en/functions/misc/about_dialog.rst
@@ -3,7 +3,7 @@
 About Dialog
 ************
 
-This element creates a `button <button.html>`_ which shows a simple about dialog, listing Mapbender's version. The button can be placed into the toolbar and the footer region.
+This element creates a :ref:`button` which shows a simple about dialog, listing the version of your Mapbender installation. The button can be placed into the toolbar and the footer region.
 
 .. image:: ../../../figures/about_dialog.png
      :scale: 80

--- a/en/functions/misc/button.rst
+++ b/en/functions/misc/button.rst
@@ -3,7 +3,7 @@
 Button
 ******
 
-The button element provides a push button widget. Some elements like `Legend <../basic/legend.html>`_ , `Layertree <../basic/layertree.html>`_, `FeatureInfo <../basic/feature_info.html>`_, `Line/Area Ruler <../basic/ruler.html>`_ and  `PrintClient <../export/printclient.html>`_ need a button to be displayed/activated if not defined in a frame.
+The button element provides a push button widget. Some elements like :ref:`legend`, :ref:`layertree`, :ref:`feature_info`, :ref:`ruler` and :ref:`printclient` need a button to be displayed/activated if not defined in a frame.
 
 Buttons optionally can be grouped, so that only one button in a group can be active at any given time. This is done by the group paramter.
 You can define a button that refers to a website or script using the click paramter. You can only choose features as target parameter, which have been added in the Map area or footer before.
@@ -46,7 +46,7 @@ You can add buttons for features which are integrated in the Map area. For examp
 Button for the legend element
 ------------------------------
 
-The legend is very helpful because it provides information about the Map area. In this user example, the legend is integrated in the Map area. You can find a descripton of how to configure the legend element in this documentation at `Legend <../basic/legend.html>`_.
+The legend is very helpful because it provides information about the Map area. In this user example, the legend is integrated in the Map area. You can find a descripton of how to configure the legend element in this documentation under :ref:`legend`.
 You can add a button for the legend by following these steps:
 
 First, you have to select the button element by clicking on the ``+`` - symbol in the Toolbar section in the Layouts tab.
@@ -96,7 +96,7 @@ You can add this button, like the legend button, by clicking on the ``+`` -symbo
 .. image:: ../../../figures/de/button_distance_dialog.png
      :scale: 80
      
-In this example, the title (*Title*) of the button is "Line ruler". The element references to a *Target* called "line". This element was created beforehand with the feature Line/Area Ruler. You can find a description on how to create this feature under `Line/Area Ruler <../basic/ruler.html>`_.
+In this example, the title (*Title*) of the button is "Line ruler". The element references to a *Target* called "line". This element was created beforehand with the feature Line/Area Ruler. You can find a description on how to create this feature under :ref:`ruler`.
 
 To group this button and the button for the area ruler, you have to put a group name in the field *Group*. In this example, the name of the group is "measure". You also have to add this group name to the button for the area ruler. 
 

--- a/en/functions/misc/dimensions_handler.rst
+++ b/en/functions/misc/dimensions_handler.rst
@@ -44,7 +44,7 @@ There are two ways to control the time of the WMS. On the one hand, each service
 Timeslider in context menu
 --------------------------
 
-A timeslider can be integrated via the layertree as an option in the context menu of the layer. To do this, the "Dimension" option must be activated in the `Layertree <../basic/layertree.html>`_ element.
+A timeslider can be integrated via the layertree as an option in the context menu of the layer. To do this, the "Dimension" option must be activated in the :ref:`layertree` element.
 
 .. image:: ../../../figures/wmst_layertree.png
      :scale: 80

--- a/en/functions/misc/wms_loader.rst
+++ b/en/functions/misc/wms_loader.rst
@@ -41,7 +41,7 @@ This template can be used to insert the element into a YAML application.
 How to add a WMS by defining a link
 ====================================
 
-You can add a WMS to Mapbender by defining a link, e. g. in your :ref:`WMS featureinfo<feature_info>` or your search results. The link has to look like this:
+You can add a WMS to Mapbender by defining a link, e. g. in your :ref:`feature_info` or your search results. The link has to look like this:
 
 .. code-block:: html
 

--- a/en/functions/misc/wms_loader.rst
+++ b/en/functions/misc/wms_loader.rst
@@ -22,7 +22,8 @@ Configuration
 * **Default format:** image/png, image/gif, image/jpeg (default: image/png).
 * **Default info format:** text/html, text/xml, text/plain (default: text/html).
 
-You need a button to show this element. See `button <button.html>`_ for inherited configuration options.
+You need a :ref:`button` to show this element.
+
 
 YAML-Definition:
 ----------------

--- a/en/installation/installation_configuration.rst
+++ b/en/installation/installation_configuration.rst
@@ -121,6 +121,7 @@ The configuration files are located under **app/config**.
 
 Find more information in: :ref:`yaml`.
 
+.. _app_cache:
 
 Production and Development environment and Caching: app.php and app_dev.php
 ---------------------------------------------------------------------------

--- a/en/installation/installation_symfony.rst
+++ b/en/installation/installation_symfony.rst
@@ -11,7 +11,7 @@ This setup allows a quick test of Mapbender without an integration into an exter
 
 In this document we assume that the SQLite database is used.
 
-* Please check the installation documentation for `Linux <installation_ubuntu.html>`_ respectively `Windows <installation_windows.html>`_ 
+* Please check the installation documentation for :ref:`Linux <installation_ubuntu>` respectively :ref:`Windows <installation_windows>`. 
 * Download the current Mapbender version https://mapbender.org/builds/.
 * Extract Mapbender in an arbitrary directory.
 * Start the Symfony webserver.

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -101,7 +101,7 @@ Troubleshooting is available via the following command (must be executed in the 
 .. hint:: Please note that config:check will use the php-cli version. The settings may be different from your webserver PHP settings. Please use php -r 'phpinfo();' to show your PHP webserver settings.
 
 Congratulations! Mapbender is now set up correctly and ready for further configuration.
-Find Information about the first steps with Mapbender in the :ref:`quickstart`.
+Find Information about the first steps with Mapbender in the :ref:`Mapbender Quickstart <quickstart>`.
 
 
 Optional

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -28,7 +28,7 @@ Installation of mandatory PHP extensions:
 
     sudo apt install php-gd php-curl php-cli php-xml php-sqlite3 sqlite3 php-apcu php-intl openssl php-zip php-mbstring php-bz2
 
-* Please check the Mapbender FAQ page for further PHP settings:  `FAQ <../faq.html>`_. 
+* Please check the :ref:`faq` for further PHP settings. 
 
 
 Unpack and register to web server
@@ -101,7 +101,7 @@ Troubleshooting is available via the following command (must be executed in the 
 .. hint:: Please note that config:check will use the php-cli version. The settings may be different from your webserver PHP settings. Please use php -r 'phpinfo();' to show your PHP webserver settings.
 
 Congratulations! Mapbender is now set up correctly and ready for further configuration.
-Find Information about the first steps with Mapbender: `Mapbender Quickstart Document <../quickstart.html>`_.
+Find Information about the first steps with Mapbender in the :ref:`quickstart`.
 
 
 Optional

--- a/en/installation/installation_update.rst
+++ b/en/installation/installation_update.rst
@@ -14,7 +14,7 @@ To update Mapbender you have to do the following steps:
 * Templates: If you are using your own template, you have to compare your scripts with the new scripts (are there any changes?)
 * print templates: if you use your own print templates: copy them back to app/Resources/MapbenderPrintBundle/templates/.
 * Import the demo applications either via bin/composer run reimport-example-apps or via the web administration
-* At https://doc.mapbender.org/en/installation/installation_ubuntu.html under the section **Unpack and register in your Web-Server** you can see how the config file for the Apache Alias should look like
+* At :ref:`installation_ubuntu` under the section **Unpack and register in your Web-Server** you can see how the config file for the Apache Alias should look like
 * That's all! Have a look at your new Mapbender version
 
 .. hint::

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -201,5 +201,5 @@ Troubleshooting is available via the following command (must be executed in the 
 Further information can be found at :ref:`mapbender_config_check`.
 
 Congratulations! Mapbender is now set up correctly and ready for further configuration.
-Find Information about the first steps with Mapbender in the :ref:`quickstart`.
+Find Information about the first steps with Mapbender in the :ref:`Mapbender Quickstart <quickstart>`.
 

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -59,7 +59,7 @@ Unzip the Zip archive, for example under c:\\php .
     extension=php_zip.dll
     extension=php_bz2.dll
 
-* Please check the Mapbender FAQ page for further PHP settings:  `FAQ <../faq.html>`_. 
+* Please check the :ref:`faq` for further PHP settings. 
 
 
 Extract Mapbender and register to web server
@@ -183,9 +183,6 @@ First steps
 
 The Mapbender installation can now be accessed under **http://[hostname]/mapbender/**.
 
-More information at:  `Mapbender Quickstart Document <../quickstart.html>`_. 
-
-
 
 **Check if the alias is working**
 
@@ -204,5 +201,5 @@ Troubleshooting is available via the following command (must be executed in the 
 Further information can be found at: https://doc.mapbender.org/en/customization/commands.html#app-console-mapbender-config-check
 
 Congratulations! Mapbender is now set up correctly and ready for further configuration.
-Find Information about the first steps with Mapbender: `Mapbender Quickstart Document <../quickstart.html>`_.
+Find Information about the first steps with Mapbender in the :ref:`quickstart`.
 

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -198,7 +198,7 @@ Troubleshooting is available via the following command (must be executed in the 
 
 .. hint:: Please note that config:check will use the php-cli version. The settings may be different from your webserver PHP settings. Please use php -r 'phpinfo();' to show your PHP webserver settings.
 
-Further information can be found at: https://doc.mapbender.org/en/customization/commands.html#app-console-mapbender-config-check
+Further information can be found at :ref:`mapbender_config_check`.
 
 Congratulations! Mapbender is now set up correctly and ready for further configuration.
 Find Information about the first steps with Mapbender in the :ref:`quickstart`.

--- a/en/installation/migration.rst
+++ b/en/installation/migration.rst
@@ -75,7 +75,7 @@ Migration to Mapbender 3.2
 
 You can migrate older Mapbender installations to Mapbender 3.2.
 
-Check the `Mapbender Update Process <https://doc.mapbender.org/en/installation/installation_update.html>`_
+Check the :ref:`installation_update` Guide.
 
 * Make sure you have PHP >= 7.1.0 and PHP < 8 
 * Provide a backup of your database. 
@@ -121,6 +121,8 @@ You can update the configuration with the following SQL.
 
 3. For choice: Please note that key or value are passed flipped that means value and the key- see also `Best Practices Page <https://github.com/mapbender/mapbender/wiki/Best-practices:-form-types#inversion-of-choices>`_
 
+.. code-block:: sql
+    
     choices:
         Bonn - this is the value not the key: Bonn
         Cologne - this is the value not the key: Cologne

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -132,7 +132,7 @@ The application overview site displays a list of all available applications. The
 
 There are three different options to create an application: 
 
-An application can be created out of an already existing one. This can be done via a click on the |mapbender-button-copy| button in the application overview. The application will receive the same title and URL title with the appendix *"imp"*. All previously defined elements and configurations will be transferred as well. Another possibility is the import of an application. Further information can be found on the following page `YAML Configuration <./customization/yaml.html>`_.
+An application can be created out of an already existing one. This can be done via a click on the |mapbender-button-copy| button in the application overview. The application will receive the same title and URL title with the appendix *"imp"*. All previously defined elements and configurations will be transferred as well. Another possibility is the import of an application. Further information can be found under :ref:`yaml`.
 
 Furthermore, new applications can be created from scratch. The required steps are explained in the following:
 
@@ -140,7 +140,7 @@ Furthermore, new applications can be created from scratch. The required steps ar
 
 #. After that, select a template in order to define the layout of your application. The options are: Fullscreen, Fullscreen alternative, Mapbender Mobile template. It is also possible to define your own template and assign it to a new application.
 
-.. tip:: Please note that the style-, icon- and layout-configurations are set up via css- and twig-files. Read more about template generation at `How to create your own Template? <customization/templates.html>`_.
+.. tip:: Please note that the style-, icon- and layout-configurations are set up via css- and twig-files. Read more about template generation under :ref:`templates`.
 
 #. Define a title, URL title and a description (optional). Title and URL title can be identical. However, the URL title has to follow the usual URL syntax.
 
@@ -148,7 +148,7 @@ Furthermore, new applications can be created from scratch. The required steps ar
 
 #. Under the section Map engine, choose your preferred OpenLayers version to manage the application's map.
 
-#. Set a tick at *"persistent map state"*, to make certain map parameters and configurations persistent. Further information can be found on the following site: `share <share.html>`_.
+#. Set a tick at *"persistent map state"*, to make certain map parameters and configurations persistent. Further information can be found in :ref:`share`.
 
 #. Click *"save"* to save and create your application. It is now possible to add elements (e.g. map, navigation bar, legend) and services to your applicaiton.
 
@@ -181,7 +181,7 @@ Now you should have an idea about how easy it is to change a Mapbender applicati
   .. image:: ../figures/mapbender_application_add_element.png
      :width: 100%
 
-In the following, you find a complete list of all elements and their functionalities. For a more detailed description, please have a look at the corresponding chapters in the `mapbender documentation <index.html>`_.
+In the following, you find a complete list of all elements and their functionalities. For a more detailed description, please have a look at the corresponding chapters in the :ref:`Table of Contents<welcome>`.
 
 * About dialog: Shows information about Mapbender in an about dialog
 * Activity indicator: Shows HTTP activity
@@ -322,7 +322,7 @@ Sources can be individually configured. This can be useful if you, for instance,
 
 **Dimensions:**
 
-This function is relevant for sources with a time dimension. Further information can be found on the following page: `Dimensions Handler <dimensions_handler.html>`_.
+This function is relevant for sources with a time dimension. Further information can be found under :ref:`dimensions_handler`.
 
 **Vendor Specific Parameter:**
 

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -67,12 +67,12 @@ Installation
 ============
 
 This quickstart explains the basics of Mapbender and serves as a quick introduction after your first successful installation.
-For the installation of Mapbender have a look at `Installation <installation.html>`_.
+For the installation of Mapbender have a look at :ref:`installation`.
 
 1. Start Mapbender
 ==================
 
-#. Choose  ``Mapbender`` from the start menu (if a shortcut was already created) or visit http://localhost/mapbender/app.php (this address can be slightly different depending on how the Apache Alias was created in the file /etc/apache2/sites-available/mapbender.conf, more information at `Installation <installation.html>`_).
+#. Choose  ``Mapbender`` from the start menu (if a shortcut was already created) or visit http://localhost/mapbender/app.php (this address can be slightly different depending on how the Apache Alias was created in the file /etc/apache2/sites-available/mapbender.conf, more information at :ref:`installation`).
  
 #. The application should then appear in your browser window.
 

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -247,6 +247,8 @@ The sources pages provides a user with the following functions:
      :width: 100%
 
 
+.. _load_sources:
+
 Load sources
 ------------
 

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -233,7 +233,7 @@ Try it yourself
 4. Configure Sources
 ====================
 
-Mapbender can handle sources of the type OGC WMS or OGC WMTS / TMS. Via a click on ``Sources``, one can navigate to an overview of all uploaded sources. There is a second list called *"Shared instances*" which only provides sources of the type shared. Further information about bound and shared instances can be found here: :ref:`Layerset <layerset>` .
+Mapbender can handle sources of the type OGC WMS or OGC WMTS / TMS. Via a click on ``Sources``, one can navigate to an overview of all uploaded sources. There is a second list called *"Shared instances*" which only provides sources of the type shared. Further information about bound and shared instances can be found here: :ref:`layerset`.
 
 The sources pages provides a user with the following functions:
 

--- a/static404.html
+++ b/static404.html
@@ -13,7 +13,7 @@
 
   
   
-    <link rel="shortcut icon" href="/_static/mapbender3.ico"/>
+    <link rel="shortcut icon" href="/_static/mapbender.ico"/>
   
   
   


### PR DESCRIPTION
...which is now consistently `:ref:` for all internal documentation crosslinks.

Advantages:

- It's shorter and thus faster to implement.
- It adjusts automatically to text changes on pages.
- It's flexible to use with whole pages or page sections.

This is part of #383 and is a chore change to support better link implementation, as seen in #389 .


(and as usual, this PR also adds small independent changes to some documentation pages, like formatting fixes.)