### PR TITLE
Adjust Symfony link

### DIFF
--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -73,9 +73,7 @@ Wenn Sie eine weitere Datenbank verwenden möchten, müssen Sie eine zweite Date
 
 In den Elementen SearchRouter und Digitizer kann nun auf die Datenbankverbindung (connection) mit dem Namen **search_db** verwiesen werden.
 
-Weitere Informationen unter:
-
-Symfony Dokumentation <https://symfony.com/doc/current/best_practices/configuration.html>`_)
+Weitere Information über diese Konfigurationsmöglichkeit gibt es in der `Symfony Dokumentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
 
 Mapbender verwendet Doctrine. Doctrine ist eine Sammlung von PHP-Bibliotheken und bietet einen objektrelationalen Mapper und eine Datenbankabstraktionsschicht (`Doctrine Projektseite <https://www.doctrine-project.org/>`_).
 

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -73,9 +73,7 @@ If you want to use another database, you have to define a database connection wi
 
 Now, you can refer to the database **search_db** in the elements SearchRouter and Digitizer.
 
-More information:
-
-Symfony documentation <http://symfony.com/doc/current/best_practices/configuration.html>`_)
+To learn more about this structure, visit the `Symfony documentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
 
 Mapbender uses Doctrine. Doctrine is a collection of PHP libaries (`Doctrine project <http://www.doctrine-project.org/>`_).
 


### PR DESCRIPTION
Small leftover fix that adjusts a link to Symfony docs to its newest iteration and corrects a formatting error in Sphinx.