### PR TITLE
Fix indented bullet points

### DIFF
--- a/de/architecture/components.rst
+++ b/de/architecture/components.rst
@@ -85,7 +85,7 @@ Link zum GitHub-Repository: https://github.com/mapbender/mapbender-starter
 
 Externe Repositories
 *********************
-Noch mehr mit Mapbender zusammenhängende Repositories finden sich auf GitHub. Verschiedene Anbieter können auf dieser Plattform Mapbender-spezifische Bundles anbieten; bspw. das DesktopIntegrationBundle, welches von der `WhereGroup <https://wheregroup.com>`__ bereitgestellt und von Kunden gesponsert wird.
+Noch mehr mit Mapbender zusammenhängende Repositories finden sich auf GitHub. Verschiedene Anbieter können auf dieser Plattform Mapbender-spezifische Bundles anbieten; z.B. das DesktopIntegrationBundle, welches von der `WhereGroup <https://wheregroup.com>`__ bereitgestellt und von Kunden gesponsert wird.
 
 Die WhereGroup bietet Mapbender-Bundles in GitHub an: https://github.com/WhereGroup
 

--- a/de/architecture/directory_structure.rst
+++ b/de/architecture/directory_structure.rst
@@ -101,7 +101,7 @@ Dieses Verzeichnis muss vom Webserver veröffentlicht werden. Der ALIAS muss auf
 
 Es kontrolliert:
 
-* den FrontendController (PHP-Script, welches aufgerufen werden kann). Das sind **app.php** für die Produktiv-Umgebung und **app_dev.php** für die Entwicklungsversion. Die Entwicklungsversion beinhaltet bspw. die Instrumente für Performance-Tests.
+* den FrontendController (PHP-Script, welches aufgerufen werden kann). Das sind **app.php** für die Produktiv-Umgebung und **app_dev.php** für die Entwicklungsversion. Die Entwicklungsversion beinhaltet z.B. die Instrumente für Performance-Tests.
 
 * dieses Verzeichnis beinhaltet die statischen Ressourcen wie css, js, favicon etc.
 

--- a/de/backend/applications/layerset.rst
+++ b/de/backend/applications/layerset.rst
@@ -114,7 +114,7 @@ Damit kann Mapbender auf die unterschiedlichen Art und Weisen reagieren, die ein
 Freie und private Instanzen
 ---------------------------
 
-Alle Layerset-Instanzen werden standardmäßig als private Instanzen erstellt. Private Instanzen müssen für jede Anwendung individuell konfiguriert werden. Freie Instanzen ermöglichen die Einbindung einer vorkonfigurierten Layerset-Instanz in mehreren Anwendungen. Freie Instanzen können bspw. verwendet werden, um für mehrere Anwendungen, welche gleich konfigurierte Layerset-Instanzen teilen, nicht mehrmals die gleiche Konfiguration durchführen zu müssen. Änderungen einer freien Instanz sind in allen Anwendungen, in denen die Instanz eingebunden ist, wirksam.
+Alle Layerset-Instanzen werden standardmäßig als private Instanzen erstellt. Private Instanzen müssen für jede Anwendung individuell konfiguriert werden. Freie Instanzen ermöglichen die Einbindung einer vorkonfigurierten Layerset-Instanz in mehreren Anwendungen. Freie Instanzen können verwendet werden, um für mehrere Anwendungen, welche gleich konfigurierte Layerset-Instanzen teilen, nicht mehrmals die gleiche Konfiguration durchführen zu müssen. Änderungen einer freien Instanz sind in allen Anwendungen, in denen die Instanz eingebunden ist, wirksam.
 
 Eine Layerset-Instanz kann in der Bearbeitungsansicht über den blauen Button "In freie Instanz umwandeln" umgeändert werden. Über den gleichen Button lässt sich eine freie Instanz wieder in eine private Instanz umwandeln.
 
@@ -171,7 +171,7 @@ Basesources
 
 Es gibt verschiedene Möglichkeiten, den Ebenenbaum zu füllen und mit Basesources zu arbeiten:
 
-- Bspw. durch das Verstecken im Layerbaum und das Nutzen des `BaseSourceSwitcher <../basic/basesourceswitcher>`_.
+- Z.B durch das Verstecken im Layerbaum und das Nutzen des `BaseSourceSwitcher <../basic/basesourceswitcher>`_.
 - Oder auch mit den Möglichkeiten im `Ebenenbaum mit der thematische Layer <../basic/layertree>`_ zu arbeiten. Diese Option zeigt den Namen des Layersets entlang eines Ordners und einer Checkbox im Ebenenbaum. Dabei lässt sich konfigurieren, ob der Ordner nach dem Öffnen der Anwendung angezeigt werden soll; zudem ist es möglich, den Ordner aufgeklappt darzustellen.
 
 

--- a/de/backend/applications/layouts.rst
+++ b/de/backend/applications/layouts.rst
@@ -17,17 +17,17 @@ Eine Übersicht über alle Elemente gibt es unter :ref:`elements_de`.
 
 Layout des Fullscreen Templates:
 
-  * Obere Werkzeugleiste (Region für die Platzierung von Buttons, Links, HTML, ...)
-  * Sidepane (Seitenleisten-Region für den Ebenenbaum, die Legende, die Suche, den Druck, HTML, ...)
-  * Kartenbereich (Region für die Karte, die Maßstabsleiste, ...)
-  * Fußzeile (Region für das Impressum, die Aktivitätsanzeige, die Maßstabsauswahl, ...)
+* Obere Werkzeugleiste (Region für die Platzierung von Buttons, Links, HTML, ...)
+* Sidepane (Seitenleisten-Region für den Ebenenbaum, die Legende, die Suche, den Druck, HTML, ...)
+* Kartenbereich (Region für die Karte, die Maßstabsleiste, ...)
+* Fußzeile (Region für das Impressum, die Aktivitätsanzeige, die Maßstabsauswahl, ...)
 
 
 Layout des Mobilen Templates:
 
-  * Fußzeile (Region für das Copyright, die Aktivitätsanzeige, die Maßstabsauswahl, ...)
-  * Kartenbereich (Region für die Karte, die Maßstabsleiste, ...)
-  * MobilePane (Region für Dialoge wie den Ebenenbaum, die Legende, den Hintergrundwechsler, die Infoabfrage, ...)
+* Fußzeile (Region für das Copyright, die Aktivitätsanzeige, die Maßstabsauswahl, ...)
+* Kartenbereich (Region für die Karte, die Maßstabsleiste, ...)
+* MobilePane (Region für Dialoge wie den Ebenenbaum, die Legende, den Hintergrundwechsler, die Infoabfrage, ...)
 
 
 Der |mapbender-button-add| Button rechts oberhalb des Bereichs ermöglicht das Hinzufügen von Elementen. Nach dem Klick auf den Button öffnet sich eine Dialogmaske, die die Auswahl eines Elements und dessen anschließende Konfiguration ermöglicht.
@@ -43,10 +43,10 @@ Konfigurationsmöglichkeiten der Oberen Werkzeugleiste und Fußzeile
 ******************************************************************
 Die Regionen der Oberen Werkzeugleiste und der Fußzeile bieten folgende Konfigurationsmöglichkeiten über den |mapbender-button-edit| Button an:
 
-  * **Bildschirmtyp** (Alle, Mobil, Desktop. Standard: Alle) Bei dieser Option wird der Bereich für die nicht ausgewählte Geräteart ausgeblendet. *Alle* zeigt die Region auf allen Geräten an.
-  * **Ausrichtung** (Links, Rechts, Zentriert. Standard: Rechts.): Die Ausrichtung definiert die Positionierung der Elemente innerhalb der Bereiche.
-  * **Checkbox Schaltflächen zu Menü zusammenfassen**: Konfiguriert ein Ausklappmenü, welches die in den Bereich eingebundenen Elemente umfasst.
-  * **Menütitel-Textfeld**: Mit dieser Textbox lässt sich dem Ausklappmenü eine Beschriftung zuweisen.
+* **Bildschirmtyp** (Alle, Mobil, Desktop. Standard: Alle) Bei dieser Option wird der Bereich für die nicht ausgewählte Geräteart ausgeblendet. *Alle* zeigt die Region auf allen Geräten an.
+* **Ausrichtung** (Links, Rechts, Zentriert. Standard: Rechts.): Die Ausrichtung definiert die Positionierung der Elemente innerhalb der Bereiche.
+* **Checkbox Schaltflächen zu Menü zusammenfassen**: Konfiguriert ein Ausklappmenü, welches die in den Bereich eingebundenen Elemente umfasst.
+* **Menütitel-Textfeld**: Mit dieser Textbox lässt sich dem Ausklappmenü eine Beschriftung zuweisen.
 
 .. tip:: **Hinweis**: Das Ausklappmenü ist besonders sinnvoll, wenn die Anwendung für mobile Endgeräte ausgerichtet sein soll. Unter :ref:`CSS_de` findet sich ein Codebaustein, der die Bedienbarkeit bei Anwendungen mit vielen Elementen erhöht. 
 
@@ -67,11 +67,9 @@ Die Ansichtsoptionen für die Sidepane können im Sidepane-Bereich im Mapbender-
 
 Die Option **Typ** zeigt die Sidepane-Elemente in unterschiedlichen Ansichten an:
 
-  - ``Akkordeon`` zeigt alle hinzugefügten Elemente in Reitern.
-
-  - ``Buttons`` zeigt alle hinzugefügten Elemente über Buttons.
-
-  - ``Unformatiert`` verzichtet auf Styling-Optionen und zeigt die Elemente direkt und in der im Backend gewählten Reihenfolge untereinander an.
+- ``Akkordeon`` zeigt alle hinzugefügten Elemente in Reitern.
+- ``Buttons`` zeigt alle hinzugefügten Elemente über Buttons.
+- ``Unformatiert`` verzichtet auf Styling-Optionen und zeigt die Elemente direkt und in der im Backend gewählten Reihenfolge untereinander an.
 
 
 Element-Buttonleiste

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -15,13 +15,12 @@ Datenbank
 *********
 Zur Konfiguration der Datenbankverbindung werden die Dateien ``parameters.yml`` und ``config.yml`` verwendet. In der ``parameters.yml`` werden Variablen für die Datenbankverbindung definiert. Es können mehrere Datenbankverbindungen definiert werden. Die Variablen werden in der ``config.yml`` verarbeitet. Zu jeder Datenbankverbindung wird ein Alias vergeben.
 
-* database_driver: Der Datenbanktreiber. Mögliche Werte sind:
-
-  * pdo_sqlite - SQLite PDO driver
-  * pdo_mysql - MySQL PDO driver
-  * pdo_pgsql - PostgreSQL PDO driver
-  * oci8 - Oracle OCI8 driver
-  * pdo_oci - Oracle PDO driver
+* **database_driver**: Der Datenbanktreiber. Mögliche Werte sind:
+    * pdo_sqlite - SQLite PDO driver
+    * pdo_mysql - MySQL PDO driver
+    * pdo_pgsql - PostgreSQL PDO driver
+    * oci8 - Oracle OCI8 driver
+    * pdo_oci - Oracle PDO driver
 
   Beachten Sie, dass Sie den entsprechenden PHP-Treiber installiert bzw. aktiviert haben.
 
@@ -168,16 +167,16 @@ Dies kann nur für die gesamte Mapbender Installation angepasst werden (nicht f�
 
   Folgende Sprachcodes sind verfügbar:
 
-    * en für Englisch (Standard)
-    * de für Deutsch
-    * es für Spanisch
-    * fr für französisch,
-    * it für Italienisch
-    * nl für Niederländisch
-    * pt für Portugiesisch
-    * ru für Russisch
-    * tr für Türkisch
-    * uk für Ukrainisch
+* en für Englisch (Standard)
+* de für Deutsch
+* es für Spanisch
+* fr für französisch,
+* it für Italienisch
+* nl für Niederländisch
+* pt für Portugiesisch
+* ru für Russisch
+* tr für Türkisch
+* uk für Ukrainisch
 
 Eine Konfiguration könnte wie folgt aussehen:
 

--- a/de/elements/editing/digitizer/digitizer_configuration.rst
+++ b/de/elements/editing/digitizer/digitizer_configuration.rst
@@ -372,15 +372,13 @@ Die möglichen Optionen sind:
 * **label:** Beschriftung mit dem Namen der Erfassungsoberfläche
 * **minScale:** Minimaler Maßstab, ab dem die Features in der Karte angezeigt werden (z.B. minscale: 5000 = Anzeige ab einem Maßstab über 1:5000, beim rauszoomen)
 * **featureType:** Verbindung zur Datenbank
-
-  * connection: Name der Datenbank-Verbindung aus der parameters/config.yml
-  * table: Name der Tabelle, in der das FeatureType gespeichert wird
-  * uniqueId: Name der Spalte mit dem eindeutigen Identifier (Standard bei Leerwert: [id])
-  * geomType: Geometrietyp
-  * geomField: Attributspalte, in der die Geometrie liegt.
-  * srid: Koordinatensystem im EPSG-Code
-  * filter: Datenfilter über Werte in einer definierten Spalte, z.B. filter: interests = 'maps'
-
+    * connection: Name der Datenbank-Verbindung aus der parameters/config.yml
+    * table: Name der Tabelle, in der das FeatureType gespeichert wird
+    * uniqueId: Name der Spalte mit dem eindeutigen Identifier (Standard bei Leerwert: [id])
+    * geomType: Geometrietyp
+    * geomField: Attributspalte, in der die Geometrie liegt.
+    * srid: Koordinatensystem im EPSG-Code
+    * filter: Datenfilter über Werte in einer definierten Spalte, z.B. filter: interests = 'maps'
 * **openFormAfterEdit:** Nach der Erfassung einer Geometrie öffnet sich das Erfassungsformular (Standard: true).
 * **zoomScaleDenominator:** Zoomstufen, die für das Zoomen auf das Objekt gewählt wird (Standard: 100).
 * **allowEditData:** Daten dürfen editiert und gespeichert werden [true/false]. Es erscheint immer eine Speichern Schaltfläche.
@@ -473,13 +471,14 @@ Definition der Objekttabelle
 Der Digitizer stellt eine Objekttabelle bereit. Über diese kann auf die Objekte gezoomt werden und das Bearbeitungsformular kann geöffnet werden. Die Objekttabelle ist sortierbar. Die Breite der einzelnen Spalten kann optional in Prozent oder Pixeln angegeben werden.
 
 * **tableFields:** Definition der Spalten für die Objekttabelle.
-   * Definition einer Spalte: [Tabellenspalte]: {label: [Beschriftung], width: [css-Angabe z.B. Angabe der Breite]}  # Definition einer Spalte
+    * Definition einer Spalte: [Tabellenspalte]: {label: [Beschriftung], width: [css-Angabe, z.B. Angabe der Breite]}
 * **searchType:** Suchbereich in der Karte, Anzeige aller Objekttreffer in der Tabelle oder nur aller Objekttreffer in dem derzeitigen Kartenausschnitt [all / currentExtent] (Standard: currentExtent).
 * **showExtendSearchSwitch:** Anzeige der searchType Selectbox zur Suche im Kartenausschnitt aktivieren oder deaktivieren [true/false]
 * **view:** Einstellungen zu der Objekttabelle
-   * Detaillierte Informationen zu möglichen Angaben unter https://datatables.net/reference/option/
    * **type**: Templatename [table]
    * **settings**: Einstellungen zum Funktionsumfang der Objekttabelle *(neu hinzugefügt, noch nicht vollst. dokumentiert!)*
+
+Detaillierte Informationen zu möglichen Angaben finden Sie unter https://datatables.net/reference/option/
 
 .. code-block:: yaml
 

--- a/de/elements/export/printclient.rst
+++ b/de/elements/export/printclient.rst
@@ -239,7 +239,7 @@ Sobald "dynamic_image" im Drucklayout vorliegt, wird nach einem Bild mit dem Nam
 *Dynamischer Text*
 ------------------
 
-Über das Element "dynamic_text" wird die Gruppenbeschreibung der ersten zugewiesenen Gruppe im Ausdruck eingetragen. Das Textfeld verhält sich genauso wie andere Textfelder und kann beliebig viele Zeichen enthalten. Sie können den dynamischen Text unabhängig von dem dynamischen Bild einbinden und bspw. für Copyright-Hinweise nutzen.
+Über das Element "dynamic_text" wird die Gruppenbeschreibung der ersten zugewiesenen Gruppe im Ausdruck eingetragen. Das Textfeld verhält sich genauso wie andere Textfelder und kann beliebig viele Zeichen enthalten. Sie können den dynamischen Text unabhängig von dem dynamischen Bild einbinden und beispielweise für Copyright-Hinweise nutzen.
 
 
 
@@ -421,7 +421,7 @@ Der Parameter `mapbender.print.queue.memory_limit` (string; Standard: 1G) muss a
 *Direktdruck*
 -------------
 
-Über den Parameter `mapbender.print.memory_limit` (string or null; Standard: null) kann das Speicherlimit auch für den Direktdruck angepasst werden (mögliche Werte sind bspw. 512M, 2G, 2048M, etc.).
+Über den Parameter `mapbender.print.memory_limit` (string or null; Standard: null) kann das Speicherlimit auch für den Direktdruck angepasst werden (mögliche Werte sind z.B. 512M, 2G, 2048M, etc.).
 Ist der Parameter "null" eingestellt, passt sich der Druck an die vorgegebene php.ini-Begrenzung an, der Wert "-1" steht für unbegrenzte Speichernutzung.
 
 

--- a/de/elements/export/printclient.rst
+++ b/de/elements/export/printclient.rst
@@ -49,9 +49,9 @@ Der PrintClient kann im Backend konfiguriert werden. Er greift dabei auf Druckvo
 
 Über die Konfiguration folgender Werte können optionale Felder im Druckdialog ermöglicht werden. Eine Beispielkonfiguration mit vier Feldern (Titel, zwei Kommentarfelder, Bearbeiter) gibt die YAML-Definition.
 
-  * **title**: Name des optionalen Feldes, der Standardwert ist null (keine optionalen Felder sind definiert).
-  * **label**: Beschriftung des optionalen Feldes.
-  * **options**: { required: true } : Typ des optionalen Feldes, muss true oder false sein.
+* **title**: Name des optionalen Feldes, der Standardwert ist null (keine optionalen Felder sind definiert).
+* **label**: Beschriftung des optionalen Feldes.
+* **options**: { required: true } : Typ des optionalen Feldes, muss true oder false sein.
 
 * **Zeige Pflichtfelder zuerst (Display required fields first)**: Ist diese Checkbox aktiv, erscheinen Pflichtfelder im Druckdialog ganz oben.
 
@@ -108,14 +108,14 @@ Diese Vorlage kann genutzt werden, um das Element in einer YAML-Anwendung einzub
 Verzeichnisse
 -------------
 
-**Der Nordpfeil:**
-* Das Bild des Nordpfeils befindet sich unter **app/Resources/MapbenderPrintBundle/images/**. Er kann durch ein anderes Bild ersetzt werden.
+* **Der Nordpfeil:**
+    * Das Bild des Nordpfeils befindet sich unter **app/Resources/MapbenderPrintBundle/images/**. Er kann durch ein anderes Bild ersetzt werden.
 
-**Die Print Templates:**
-* Die Vorlagen befinden sich unter **app/Resources/MapbenderPrintBundle/templates/**. Es können eigene Druckvorlagen erstellt und hinzugefügt werden.
+* **Die Print Templates:**
+    * Die Vorlagen befinden sich unter **app/Resources/MapbenderPrintBundle/templates/**. Es können eigene Druckvorlagen erstellt und hinzugefügt werden.
 
-**Die Druckdateien:**
-* Die Druckdateien werden in dem Standard-Downloadordner Ihres Webbrowsers abgelegt. Mapbender speichert die Dateien des Warteschleifendrucks hingegen standardmäßig unter **web/prints/**.
+* **Die Druckdateien:**
+    * Die Druckdateien werden in dem Standard-Downloadordner Ihres Webbrowsers abgelegt. Mapbender speichert die Dateien des Warteschleifendrucks hingegen standardmäßig unter **web/prints/**.
 
 
 Erstellen einer individuellen Vorlage
@@ -160,24 +160,13 @@ Für die Nutzung dieser Funktion müssen die Templates angepasst und transparent
 Templates anpassen:
 
 * Elemente neu anordnen, am besten vor weißem Hintergrund
-
-  - Anordnung der Elemente im Vordergrund
-
-    + Rechtsklick Anordnung -> Ganz nach vorn
-
-  - Anordnung Karte = ganz nach hinten
-
-    + Rechtsklick Anordnung -> Ganz nach hinten
-
+    * Anordnung der Elemente im Vordergrund (Rechtsklick Anordnung → Ganz nach vorn)
+    * Anordnung Karte = ganz nach hinten (Rechtsklick Anordnung → Ganz nach hinten)
 * Alles selektieren
-
-  - STRG + A drücken
-
+    * STRG + A drücken
 * Selektion als PDF drucken
-
-  - Exportieren als PDF
-
-  - Bereich Auswahl statt Alle
+    * Exportieren als PDF
+    * Bereich Auswahl statt Alle
 
 
 Legende auf der ersten Seite

--- a/de/elements/export/printclient.rst
+++ b/de/elements/export/printclient.rst
@@ -108,14 +108,22 @@ Diese Vorlage kann genutzt werden, um das Element in einer YAML-Anwendung einzub
 Verzeichnisse
 -------------
 
-* **Der Nordpfeil:**
-    * Das Bild des Nordpfeils befindet sich unter **app/Resources/MapbenderPrintBundle/images/**. Er kann durch ein anderes Bild ersetzt werden.
+**Der Nordpfeil**
 
-* **Die Print Templates:**
-    * Die Vorlagen befinden sich unter **app/Resources/MapbenderPrintBundle/templates/**. Es können eigene Druckvorlagen erstellt und hinzugefügt werden.
+* Das Bild des Nordpfeils befindet sich unter **app/Resources/MapbenderPrintBundle/images/**.
+* Der NOrdpfeil kann durch ein anderes Bild ersetzt werden.
 
-* **Die Druckdateien:**
-    * Die Druckdateien werden in dem Standard-Downloadordner Ihres Webbrowsers abgelegt. Mapbender speichert die Dateien des Warteschleifendrucks hingegen standardmäßig unter **web/prints/**.
+
+**Die Print-Templates**
+
+* Die Vorlagen befinden sich unter **app/Resources/MapbenderPrintBundle/templates/**.
+* Es können eigene Druckvorlagen erstellt und hinzugefügt werden.
+
+
+**Die Druck-Dateien (pdf)**
+
+* Die Druckdateien werden in dem Standard-Download-Ordner Ihres Webbrowsers abgelegt oder direkt im Browser angezeigt je nach Browserkonfiguration.
+* Mapbender speichert die Dateien des Warteschleifendrucks hingegen standardmäßig unter **web/prints/**.
 
 
 Erstellen einer individuellen Vorlage

--- a/de/elements/search.rst
+++ b/de/elements/search.rst
@@ -5,7 +5,6 @@ Suchen
 
 .. toctree::
    :maxdepth: 1
-   :numbered:
 
    search/search_router.rst
    search/simplesearch.rst

--- a/de/elements/search/simplesearch.rst
+++ b/de/elements/search/simplesearch.rst
@@ -31,10 +31,10 @@ Konfiguration
 * **Query URL key:** Der Suchparameterschlüssel, der angehängt wird (z.B. ``q``).
 * **Query Whitespace replacement pattern:** Muster zum Austausch von Leerzeichen.
 * **Query key format:** Einfaches Suchformat (z.B. ``%s``).
-* **Token search/ replace (JavaScript regex):** Tokenizer spaltet/ sucht/ ersetzt regexp.
-  * Token, z.B.: ``[^a-zA-Z0-9äöüÄÖÜß]``
-  * Token search, z.B.: ``([a-zA-ZäöüÄÖÜß]{3,})``
-  * Token replace, z.B.: ``$1*``    
+* **Token search/replace (JavaScript regex):** Tokenizer spaltet/sucht/ersetzt regexp.
+    * **Token**, bspw.: ``[^a-zA-Z0-9äöüÄÖÜß]``
+    * **Token search**, bspw.: ``([a-zA-ZäöüÄÖÜß]{3,})``
+    * **Token replace**, bspw.: ``$1*``
 * **Collection path:** Dies kann ein Attributspfad sein, der vom Abfrageergebnis extrahiert wird (z.B. ``response.docs``).
 * **Label attribut:** Attribut oder mehrere Attribute , die als Ergebnis angezeigt werden sollen.
 * **Geom attribut:** Attributname der Geodaten (z.B. ``geom``).

--- a/de/elements/search/simplesearch.rst
+++ b/de/elements/search/simplesearch.rst
@@ -32,9 +32,9 @@ Konfiguration
 * **Query Whitespace replacement pattern:** Muster zum Austausch von Leerzeichen.
 * **Query key format:** Einfaches Suchformat (z.B. ``%s``).
 * **Token search/replace (JavaScript regex):** Tokenizer spaltet/sucht/ersetzt regexp.
-    * **Token**, bspw.: ``[^a-zA-Z0-9äöüÄÖÜß]``
-    * **Token search**, bspw.: ``([a-zA-ZäöüÄÖÜß]{3,})``
-    * **Token replace**, bspw.: ``$1*``
+    * **Token**, z.B.: ``[^a-zA-Z0-9äöüÄÖÜß]``
+    * **Token search**, z.B..: ``([a-zA-ZäöüÄÖÜß]{3,})``
+    * **Token replace**, z.B..: ``$1*``
 * **Collection path:** Dies kann ein Attributspfad sein, der vom Abfrageergebnis extrahiert wird (z.B. ``response.docs``).
 * **Label attribut:** Attribut oder mehrere Attribute , die als Ergebnis angezeigt werden sollen.
 * **Geom attribut:** Attributname der Geodaten (z.B. ``geom``).

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -3,7 +3,7 @@
 Installation auf Ubuntu/Debian
 ##############################
 
-Die mitgelieferte SQLite Datenbank ist für Testinstallationen geeignet. In dieser Datenbank befinden sich bereits vorkonfigurierte Demoanwendungen (die Datenbank liegt unter **<mapbender>/app/db/demo.sqlite**).
+Die mitgelieferte SQLite Datenbank ist für Testinstallationen geeignet. In dieser Datenbank befinden sich bereits vorkonfigurierte Demoanwendungen (sie liegt unter <mapbender>/app/db/demo.sqlite).
 Eine Anleitung für eine Testinstallation auf Basis des Symfony Webservers finden Sie unter :ref:`installation_symfony_de`.
 
 .. hint:: Für den Produktiveinsatz wird PostgreSQL empfohlen. Weitere Installationshinweise finden Sie im Kapitel `Optional > Mapbender Einrichtung auf PostgreSQL <#optional>`_.
@@ -14,10 +14,8 @@ Voraussetzungen
 
 - PHP >= 7.4
 - Apache Installation mit folgenden aktivierten Modulen:
-
-  * mod_rewrite
-  * libapache2-mod-php
-
+    - mod_rewrite
+    - libapache2-mod-php
 Als Webserver kann auch nginx verwendet werden. In dieser Anleitung wird darauf nicht weiter eingegangen.
 
 
@@ -165,7 +163,7 @@ Root-Benutzer für Zugriff anlegen:
 
    app/console fom:user:resetroot
 
-Weitere Informationen zur Konfiguration im Kapitel :ref:`installation_configuration_de`
+Weitere Informationen zur Konfiguration im Kapitel :ref:`installation_configuration_de`.
 
 
 **Mapbender Einrichtung auf MySQL**

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -12,10 +12,14 @@ Eine Anleitung für eine Testinstallation auf Basis des Symfony Webservers finde
 Voraussetzungen
 ---------------
 
-- PHP >= 7.4
-- Apache Installation mit folgenden aktivierten Modulen:
-    - mod_rewrite
-    - libapache2-mod-php
+* PHP >= 7.4
+* Apache Installation mit folgenden aktivierten Modulen:
+    * mod_rewrite
+    * libapache2-mod-php
+* PostgreSQL Installation
+    * Es wird empfohlen, eine PostgreSQL Datenbank für Mapbender zu verwenden.
+    * Es wird empfohlen, einen eigenen Datenbankbenutzer für den Zugriff auf die Mapbender Datenbank anzulegen.
+
 Als Webserver kann auch nginx verwendet werden. In dieser Anleitung wird darauf nicht weiter eingegangen.
 
 

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -13,17 +13,13 @@ Mapbender benötigt eine Datenbank zur Speicherung der Administrationsinformatio
 Voraussetzungen
 ---------------
 
-* PHP NTS >= 7.4 https://windows.php.net/download/)
-* Apache Installation, als Dienst eingerichtet (https://www.apachelounge.com/download/)   
-  mit folgenden aktivierten Modulen:
- 
-  * mod_rewrite
-  * mod_fcgid
- 
-* PostgreSQL Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) 
-  
-  * Es wird empfohlen eine PostgreSQL Datenbank für Mapbender zu verwenden.
-  * Es wird empfohlen einen eigenen Datenbankbenutzer für den Zugriff auf die Mapbender Datenbank anzulegen.
+1. PHP NTS >= 7.4 https://windows.php.net/download/)
+2. Apache Installation, als Dienst eingerichtet (https://www.apachelounge.com/download/) mit folgenden aktivierten Modulen:
+    * mod_rewrite
+    * mod_fcgid
+3. PostgreSQL Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)   
+    * Es wird empfohlen, eine PostgreSQL Datenbank für Mapbender zu verwenden.
+    * Es wird empfohlen, einen eigenen Datenbankbenutzer für den Zugriff auf die Mapbender Datenbank anzulegen.
 
 
 Als Webserver kann auch Nginx verwendet werden. In dieser Anleitung wird darauf nicht weiter eingegangen.

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -13,11 +13,11 @@ Mapbender benötigt eine Datenbank zur Speicherung der Administrationsinformatio
 Voraussetzungen
 ---------------
 
-1. PHP NTS >= 7.4 https://windows.php.net/download/)
-2. Apache Installation, als Dienst eingerichtet (https://www.apachelounge.com/download/) mit folgenden aktivierten Modulen:
+* PHP NTS >= 7.4 https://windows.php.net/download/)
+* Apache Installation, als Dienst eingerichtet (https://www.apachelounge.com/download/) mit folgenden aktivierten Modulen:
     * mod_rewrite
     * mod_fcgid
-3. PostgreSQL Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)   
+* PostgreSQL Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)
     * Es wird empfohlen, eine PostgreSQL Datenbank für Mapbender zu verwenden.
     * Es wird empfohlen, einen eigenen Datenbankbenutzer für den Zugriff auf die Mapbender Datenbank anzulegen.
 

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -38,13 +38,13 @@ Mapbender ist ein webbasiertes Geoportal-Framework zum Veröffentlichen, Registr
 
 Mit dieser Code-Grundlage wird die Idee eines Geoportal-Frameworks fortgesetzt. Zentrale Mapbender-Funktionen sind:
 
-  * Anwendungen können direkt im Browser erstellt, konfiguriert und gestylt werden.
-  * Dienste (wie WMS) können in einem Dienst-Repository verwaltet und mit Anwendungen verbunden werden.
-  * Das Rechtemanagement ist sowohl für einzelne Benutzer als auch Gruppen einfach zu verwalten, egal ob sie in einer Datenbank oder über LDAP gespeichert werden.
-  * Der Administrator braucht keine Zeile Code zu schreiben, da die Konfiguration über die webbasierte Administrationsoberfläche erfolgt.
-  * Suchen können konfiguriert werden.
-  * Anwendungen zur Digitalisierung können aufgebaut werden.
-  * Anwendungen können flexibel für Smartphones und Tablets angelegt werden.
+* Anwendungen können direkt im Browser erstellt, konfiguriert und gestylt werden.
+* Dienste (wie WMS) können in einem Dienst-Repository verwaltet und mit Anwendungen verbunden werden.
+* Das Rechtemanagement ist sowohl für einzelne Benutzer als auch Gruppen einfach zu verwalten, egal ob sie in einer Datenbank oder über LDAP gespeichert werden.
+* Der Administrator braucht keine Zeile Code zu schreiben, da die Konfiguration über die webbasierte Administrationsoberfläche erfolgt.
+* Suchen können konfiguriert werden.
+* Anwendungen zur Digitalisierung können aufgebaut werden.
+* Anwendungen können flexibel für Smartphones und Tablets angelegt werden.
 
 Sie brauchen nichts weiter als einen Webbrowser für diesen Schnellstart.
 

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -329,7 +329,7 @@ Diese Funktion ist für WMS-Dienste mit einer zeitlichen Dimension von Relevanz.
 
 In einer Layerset-Instanz können Vendor Specific Parameter angegeben werden, die an den WMS Request angefügt werden. Die Umsetzung folgt den Angaben der multi-dimensionalen Daten in der WMS-Spezifikation.
 
-In Mapbender können die Vendor Specific Parameter genutzt werden, um bspw. Benutzer und Gruppeninformation des angemeldeten Benutzers an die WMS Anfrage zu hängen. Es können auch feste Werte übermittelt werden.
+In Mapbender können die Vendor Specific Parameter genutzt werden, um z.B. Benutzer und Gruppeninformation des angemeldeten Benutzers an die WMS Anfrage zu hängen. Es können auch feste Werte übermittelt werden.
 
 Das folgende Beispiel zeigt die Definition eines Parameters „group“, der als Inhalt die Gruppe des gerade in Mapbender angemeldeten Nutzers weitergibt.
 
@@ -402,7 +402,7 @@ Benutzer anlegen
   .. image:: ../figures/de/mapbender_create_user.png
    :width: 100%
 
-Weitere Angaben zum Benutzer können im Reiter ``Profil`` erfolgen. In den Reitern ``Gruppen`` und ``Sicherheit`` können dem Benutzer zusätzliche Parameter, bspw. die Zugehörigkeit zu einer Gruppe, zugewiesen werden.
+Weitere Angaben zum Benutzer können im Reiter ``Profil`` erfolgen. In den Reitern ``Gruppen`` und ``Sicherheit`` können dem Benutzer zusätzliche Parameter, z.B. die Zugehörigkeit zu einer Gruppe, zugewiesen werden.
 
   .. image:: ../figures/de/mapbender_assign_user_to_group.png
    :width: 100%

--- a/en/backend/applications/layouts.rst
+++ b/en/backend/applications/layouts.rst
@@ -17,17 +17,17 @@ An overview of all elements is available under :ref:`elements`.
 
 Layout of the Fullscreen template:
 
-  * Top toolbar (region for Buttons, Links, HTML,...)
-  * Sidepane (region for Layertree, Legend, Search, Print, HTML,...)
-  * Map area (region for Map, Scalebar,...)
-  * Footer (region for Copyright, Activity Indicator, Scale select,...)
+* Top toolbar (region for Buttons, Links, HTML,...)
+* Sidepane (region for Layertree, Legend, Search, Print, HTML,...)
+* Map area (region for Map, Scalebar,...)
+* Footer (region for Copyright, Activity Indicator, Scale select,...)
 
 
 Layout of the Mobile template:
 
-  * Footer (region for Copyright, Activity Indicator, Scale select,...)
-  * Map area (region for Map, Scalebar,...)
-  * MobilePane (region for dialogs like Layertree, Legend, BaseSourceSwicther, FeatureInfo,...)
+* Footer (region for Copyright, Activity Indicator, Scale select,...)
+* Map area (region for Map, Scalebar,...)
+* MobilePane (region for dialogs like Layertree, Legend, BaseSourceSwicther, FeatureInfo,...)
 
 
 The |mapbender-button-add| button located at the top right of each region allows adding elements. After pressing the button, a dialog will open, which allows for the selection of an element and its subsequent configuration.

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -15,13 +15,12 @@ Database
 ********
 The files ``parameters.yml`` and ``config.yml`` are needed to configure databases in Mapbender. In ``parameters.yml``, (multiple) variables for database connection(s) can be defined. These variables are being processed in ``config.yml``. An alias is assigned to each database connection.
 
-* database_driver: Database driver. Possible values are:
-
-  * pdo_sqlite - SQLite PDO driver
-  * pdo_mysql - MySQL PDO driver
-  * pdo_pgsql - PostgreSQL PDO driver
-  * oci8 - Oracle OCI8 driver
-  * pdo_oci - Oracle PDO driver
+* **database_driver**: Database driver. Possible values are:
+    * pdo_sqlite - SQLite PDO driver
+    * pdo_mysql - MySQL PDO driver
+    * pdo_pgsql - PostgreSQL PDO driver
+    * oci8 - Oracle OCI8 driver
+    * pdo_oci - Oracle PDO driver
 
   Please note: Necessary PHP drivers need to be installed and activated.
 
@@ -103,16 +102,16 @@ If a translation of your browser's set language is missing in Mapbender, it will
 
 Available language codes are:
 
-    * en for English (default)
-    * de for German
-    * es for Spanish
-    * fr for French
-    * it for Italian
-    * nl for Dutch
-    * pt for Portugese
-    * ru for Russian
-    * tr for Turkish
-    * uk for Ukrainian     
+* en for English (default)
+* de for German
+* es for Spanish
+* fr for French
+* it for Italian
+* nl for Dutch
+* pt for Portugese
+* ru for Russian
+* tr for Turkish
+* uk for Ukrainian     
 
 Configuration example:
 

--- a/en/development/conventions.rst
+++ b/en/development/conventions.rst
@@ -9,21 +9,16 @@ Code conventions
 * variable names / way of coding 
 * Code documentation
 * trans convention - where to put translation
-
-
-* document the x steps on the way to a new functionality
-
-  * define the topic
-  * create a ticket
-  * create a workflow
-  * discuss the workflow with the core team and find a final solution
-  * do the programming
-  * insert License
-  * test
-  * documentation in mapbender-documentation --> rst
-  * close the ticket
-
- 
+* **document** the steps on the way to a new functionality
+    * define the topic
+    * create a ticket
+    * create a workflow
+    * discuss the workflow with the core team and find a final solution
+    * do the programming
+    * insert License
+    * test
+    * documentation in mapbender-documentation --> rst
+    * close the ticket 
 * where to put a module/element
 * naming vor files (referred to symfony convention)
 
@@ -82,30 +77,25 @@ We create a milestone for every version of Mapbender:
 
 There are some rules you should keep in mind:
 
-* **write understandable tickets!!**
+* **Write understandable tickets:**
 
-* **write your title** so that the issue is already described in the title: 
-
-  * Browser - Backend/Frontend - element - issue 
-  * like: Firefox - Frontend - layertree - option visible is not handled in frontend
-  * see ticket https://github.com/mapbender/mapbender/issues/48
-* write **comments** with all necessary information: 
-  * for bugs: describe step by step how the error can be reproduced
-  * for features: describe feature and functionality
-* when you create a new ticket do not assign it to a milestone or developer, if you are not sure
-
-* **add labels** to your ticket 
-  * bug - describes a bug that orrurs in a special version of Mapbender (add info about the version)
-  * feature - new feature
-  * enhancement - stands for feature enhancement
-  * wip - work in progress
-
-* when you work on a ticket or close it please **assign a user and milestone**
-
-* **when you close a ticket**, please:
-
-  * add a comment in the ticket and **refer to the commit**,
-  * refer to the documentation at https://doc.mapbender.org or a demo if possibile.
+* **Write your title** so that the issue is already described in the title: 
+    * Browser - Backend/Frontend - element - issue 
+    * like: Firefox - Frontend - layertree - option visible is not handled in frontend
+    * see ticket https://github.com/mapbender/mapbender/issues/48
+* Write **comments** with all necessary information: 
+    * for bugs: describe step by step how the error can be reproduced
+    * for features: describe feature and functionality
+* When you create a new ticket do not assign it to a milestone or developer, if you are not sure
+* **Add labels** to your ticket 
+    * Bug - describes a bug that orrurs in a special version of Mapbender (add info about the version)
+    * Feature - new feature
+    * Enhancement - stands for feature enhancement
+    * WIP - work in progress
+* When you work on a ticket or close it please **assign a user and milestone**
+* **When you close a ticket**, please:
+    * add a comment in the ticket and **refer to the commit**,
+    * refer to the documentation at https://doc.mapbender.org or a demo if possibile.
 
 
 
@@ -145,30 +135,22 @@ How to build a new Mapbender build
 **********************************
 
 * Resolve and close all tickets for the relevant milestone: https://github.com/mapbender/mapbender/milestones
-
 * Update https://doc.mapbender.org/en/book/versions.html
-
 * Update Changelog.md for mapbender-starter, mapbender, owsproxy, fom.
-
 * Update version number in parameters.yml.dist and push
-
 * Update version number in composer.json
-
-* Tagging: Tag at Github. You have nice capabilities for creating good tags and descriptions.
-
-  * Mapbender
-  * OWSProxy
-  * FOM
-  * Mapbender-starter
-  * Documentation
-
-* Create Pull-request to merge release branch into master
-
-  * Mapbender
-  * OWSProxy
-  * FOM
-  * Mapbender-starter
-  * Documentation
+* **Tagging**: Tag at Github. You have nice capabilities for creating good tags and descriptions.
+    * Mapbender
+    * OWSProxy
+    * FOM
+    * Mapbender-starter
+    * Documentation
+* Create **Pull requests** to merge release branch into master
+    * Mapbender
+    * OWSProxy
+    * FOM
+    * Mapbender-starter
+    * Documentation
 
 
 * Clone the source-code from the release branch

--- a/en/elements/basic/layertree.rst
+++ b/en/elements/basic/layertree.rst
@@ -82,7 +82,7 @@ In the following section, we walk through an exemplary configuration of a Layert
 
 In the example, we defined one **Layerset** with one instance:
 
-* Layerset World: 
+* Layerset **World**: 
     * Instance OSM Demo Service https://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0
 
 The registered instance of the OSM  Demo Service is automatically included in Mapbender's installation. The WMS only has to be integrated into an existing Layerset. Switch to the tab Layersets. The following example uses the Layerset "World". 
@@ -176,11 +176,11 @@ In the following section, we walk through an exemplary configuration of a Layert
 
 In the example, we define two layersets with two instances each:
 
-* Layerset Project NRW:
+* Layerset **Project NRW**:
     * Instance `DTK50 NRW <https://www.wms.nrw.de/geobasis/wms_nw_dtk50?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_ 
     * Instance `Wald NRW <http://www.wms.nrw.de/umwelt/waldNRW?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_
 
-* Layerset World: 
+* Layerset **World**: 
     * Instance OSM  Demo Service http://osm-demo.wheregroup.com/service?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0
     * Instance `GEBCO <https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv?&REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0>`_ 
 

--- a/en/elements/editing/digitizer/digitizer_configuration.rst
+++ b/en/elements/editing/digitizer/digitizer_configuration.rst
@@ -380,15 +380,13 @@ The possible options are:
 * **label:** Label of the Digitizer popup
 * **minScale:** Minimum scale, where the features should be displayed in the map (e.g. minscale: 5000 = show from a scale 'over' 1:5000, when zooming out).
 * **featureType:** Connection to the database
-
-  * connection: Name of the database-connection from the parameters/config.yml
-  * table: Table-name in which the FeatureTypes are stored
-  * uniqueId: Column-name with the unique identifier
-  * geomType: Geometry-type
-  * geomField: Column-name in which the geometry is stored
-  * srid: Coordinate-system in EPSG-code
-  * filter: Data filters for values ​​in a defined column, e.g. filter: interests = 'maps' 
-
+    * connection: Name of the database-connection from the parameters/config.yml
+    * table: Table-name in which the FeatureTypes are stored
+    * uniqueId: Column-name with the unique identifier
+    * geomType: Geometry-type
+    * geomField: Column-name in which the geometry is stored
+    * srid: Coordinate-system in EPSG-code
+    * filter: Data filters for values ​​in a defined column, e.g. filter: interests = 'maps' 
 * **openFormAfterEdit:** After creating a geometry the form popup is opened automatically to insert the attribute data (default: true)
 * **zoomScaleDenominator:** Zoom-scales to use for zooming to a feature.
 * **allowEditData:** Allow or disable functions to edit or remove data. [true/false]. The Save button is always visible.
@@ -485,13 +483,14 @@ The Digitizer provides an object table. It can be used to navigate to features (
 The width of the individual columns can optionally be specified in percent or pixels.
 
 * **tableFields:** define the columns for the feature table. 
-   * definition of a colum: [table column]: {label: [label text], width: [css-definition, like width]}  
+    * definition of a colum: [table column]: {label: [label text], width: [css-definition, like width]}  
 * **searchType:** search extent in the map, display of all features in the result table or only features displayed in the current extent [all / currentExtent] (default: currentExtent).
 * **showExtendSearchSwitch:** Activate or deactivate the display of the searchType selectbox for searching in the curret extent [true/false]
 * **view:** Settings for the object result table
-   * Detailed information on possible configurations under https://datatables.net/reference/option/
-   * **type**: Templatename [table]
-   * **settings**: Settings for the functions of the result table *(Newly added, not fully documented!)*
+    * **type**: Templatename [table]
+    * **settings**: Settings for the functions of the result table *(Newly added, not fully documented!)*
+
+You can find more detailed information on possible configurations under https://datatables.net/reference/option/.
 
 .. code-block:: yaml
 

--- a/en/elements/export/printclient.rst
+++ b/en/elements/export/printclient.rst
@@ -109,13 +109,20 @@ Directories
 -----------
 
 **The northarrow**
-* The "north arrow" image is located at **app/Resources/MapbenderPrintBundle/images/**. The "north arrow" image can be replaced to use a different image instead.
+
+* The "north arrow" image is located at **app/Resources/MapbenderPrintBundle/images/**.
+* The "north arrow" image can be replaced to use a different image instead.
+
 
 **The print templates**
+
 * The print templates can be found under **app/Resources/MapbenderPrintBundle/templates/**. 
 
-**The print files**
-Mapbender saves its generated print files in the browser's default download folder. If the queued print is used, the files will be saved under the Mapbender directory **web/prints/**.
+
+**The print pdf output**
+
+* Mapbender saves its generated print files in the browser's default download folder or shows them directly in your browser (depending on your browser settings).
+* If the queued print is used, the files will be saved under the Mapbender directory **web/prints/**.
 
 
 Create your individual templates

--- a/en/elements/export/printclient.rst
+++ b/en/elements/export/printclient.rst
@@ -49,9 +49,9 @@ The Printclient can be configured in the backend. It relies on print templates (
 
 With the configuration of the following values it is possible to enable optional fields in the print dialog. An example (title, two comment fields, name) is offered in the YAML definition.
 
-  * **title**: name of the optional field, default value is null (no optional fields are defined).
-  * **label**: Label of the optional field.
-  * **options**: { required: true } : Type of the optional field. Has to be true or false.
+* **title**: name of the optional field, default value is null (no optional fields are defined).
+* **label**: Label of the optional field.
+* **options**: { required: true } : Type of the optional field. Has to be true or false.
 
 * **Display required fields first**: If this checkbox is active, your defined required fields appear utmost.
 

--- a/en/elements/export/printclient.rst
+++ b/en/elements/export/printclient.rst
@@ -161,13 +161,9 @@ Adapt templates:
 
 * Reorder elements in front of white background
 
-  - Arrange elements into the foreground
+  - Arrange elements into the foreground (right-click Arrange → To the front)
 
-    + Right click Arrange → To the front
-
-  - Arrange map element into the background
-
-    + Right click Arrange → To the back
+  - Arrange map element into the background (right-click Arrange → To the back)
 
 * Select all
 

--- a/en/elements/export/printclient.rst
+++ b/en/elements/export/printclient.rst
@@ -160,20 +160,13 @@ To use this function, the templates have to be adapted and transparent PDF templ
 Adapt templates:
 
 * Reorder elements in front of white background
-
-  - Arrange elements into the foreground (right-click Arrange → To the front)
-
-  - Arrange map element into the background (right-click Arrange → To the back)
-
+    * Arrange elements into the foreground (right-click Arrange → To the front)
+    * Arrange map element into the background (right-click Arrange → To the back)
 * Select all
-
-  - Press CTRL + A
-
+    * Press CTRL + A
 * Print selection as PDF
-
-  -  Export as PDF
-
-  -  Selection instead of All
+    * Export as PDF
+    * Selection instead of All
 
 
 Legend on the first page

--- a/en/elements/search.rst
+++ b/en/elements/search.rst
@@ -5,7 +5,6 @@ Search
 
 .. toctree::
    :maxdepth: 1
-   :numbered:
 
    search/search_router.rst
    search/simplesearch.rst

--- a/en/elements/search/simplesearch.rst
+++ b/en/elements/search/simplesearch.rst
@@ -32,10 +32,10 @@ Configuration
 * **Query URL key:** The query parameter key to append  (e.g. ``q``).
 * **Query Whitespace replacement pattern:** Pattern for replacing white spaces.
 * **Query key format:** Simple search format  (e.g. ``%s``).
-* **Token search/ replace (JavaScript regex):** Tokenizer split/ search/ replace regexp.
-  * Token, e.g.: ``[^a-zA-Z0-9äöüÄÖÜß]``
-  * Token search, e.g.: ``([a-zA-ZäöüÄÖÜß]{3,})``
-  * Token replace, e.g.: ``$1*``  
+* **Token search/replace (JavaScript regex):** Tokenizer split/search/replace regexp.
+    * **Token**, e.g.: ``[^a-zA-Z0-9äöüÄÖÜß]``
+    * **Token search**, e.g.: ``([a-zA-ZäöüÄÖÜß]{3,})``
+    * **Token replace**, e.g.: ``$1*``
 * **Collection path:** Can be a dotted attribute path to extract from the query result (e.g. ``response.docs``).
 * **Label attribute:** Name of the attribute/s to show as result.
 * **Geom attribute:** Name of the geometry data attribute (e.g. ``geom``).

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -10,11 +10,10 @@ Mapbender is shipped with a preconfigured SQLite database which includes preconf
 Requirements
 ------------
 
-- PHP >= 7.4
-- Apache installation with the following modules activated:
-
-  * mod_rewrite
-  * libapache2-mod-php
+* PHP >= 7.4
+* Apache installation with the following modules activated:
+    * mod_rewrite
+    * libapache2-mod-php
 
 Nginx can also be used as web server (this will not be discussed in detail here).
 

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -14,6 +14,9 @@ Requirements
 * Apache installation with the following modules activated:
     * mod_rewrite
     * libapache2-mod-php
+* PostgreSQL Installation
+    * It is recommended to use a PostgreSQL database for Mapbender.
+    * It is recommended to create a database user to access the Mapbender database.
 
 Nginx can also be used as web server (this will not be discussed in detail here).
 

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -14,10 +14,10 @@ Requirements
 ------------
 
 * PHP NTS >= 7.4 https://windows.php.net/download/)
-* **Apache installation** (https://www.apachelounge.com/download/, run as service with these modules):
+* Apache installation (https://www.apachelounge.com/download/, run as service with these modules):
     * mod_rewrite
     * mod_fcgid
-* **PostgreSQL** Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) 
+* PostgreSQL Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)
     * It is recommended to use a PostgreSQL database for Mapbender. 
     * It is recommended to create a database user to access the Mapbender database.
 

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -14,15 +14,12 @@ Requirements
 ------------
 
 * PHP NTS >= 7.4 https://windows.php.net/download/)
-* Apache installation (https://www.apachelounge.com/download/ , run as service with the following modules):
- 
-  * mod_rewrite
-  * mod_fcgid
- 
-* PostgreSQL Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) 
-  
-  * It is recommended to use a PostgreSQL database for Mapbender. 
-  * It is recommended to create a database user to access the Mapbender database.
+* **Apache installation** (https://www.apachelounge.com/download/, run as service with these modules):
+    * mod_rewrite
+    * mod_fcgid
+* **PostgreSQL** Installation (https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) 
+    * It is recommended to use a PostgreSQL database for Mapbender. 
+    * It is recommended to create a database user to access the Mapbender database.
 
 
 Nginx can also be used as web server, but it will not be discussed in this manual.   

--- a/en/installation/migration.rst
+++ b/en/installation/migration.rst
@@ -173,13 +173,13 @@ Digitizer is available for Mapbender >= 3.2.2. The new Digitizer Version is 1.4.
 * You can find a demo in the `Workshop bundle <https://github.com/mapbender/mapbender-workshop/blob/release/3.2/app/config/applications/mapbender_digitize_demo.yml>`_
 * maxResults - is supported again to limit the number of features that are loaded to the application (if not defined all features will be used) (digitizer >=1.4.9)
 * For font definitions, see `issue 1308 <https://github.com/mapbender/mapbender/issues/1308>`_
-  - fontSize: 38 definition without px 
-  - labelxOffset: 18 (not supported in 3.2.3)
-  - labelYOffset: 18 (not supported in 3.2.3)
+    * fontSize: 38 definition without px 
+    * labelxOffset: 18 (not supported in 3.2.3)
+    * labelYOffset: 18 (not supported in 3.2.3)
 * Types that are not supported in 3.2.4
-  - upload
-  - select with multiselect
-  - coordinates
+    * upload
+    * select with multiselect
+    * coordinates
 * Clustering not implemented in 3.2.x
 * Style definition is limited not all OL2 styles can be defined
 * Support styling features with icons (interpret externalGraphic, graphicWidth, graphicHeight properties) (Mapbender >=3.2.7)

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -39,12 +39,12 @@ Mapbender is a web based geoportal framework to publish, register, view, navigat
 
 With this code base, we will continue the Mapbender idea of being a Geoportal framework. Key features of Mapbender are:
 
-  * Applications can be setup, configured and styled right from within the browser.
-  * Services (e.g. WMS) can be managed inside a service repository and linked to applications.
-  * Rights management are easy to maintain, for individual users and groups, whether you store them inside the database or in an LDAP.
-  * Search modules can be configured.
-  * Applications for digitalization can be setup.
-  * Mobile template can be used to provide applications for smartphones and tablets.
+* Applications can be setup, configured and styled right from within the browser.
+* Services (e.g. WMS) can be managed inside a service repository and linked to applications.
+* Rights management are easy to maintain, for individual users and groups, whether you store them inside the database or in an LDAP.
+* Search modules can be configured.
+* Applications for digitalization can be setup.
+* Mobile template can be used to provide applications for smartphones and tablets.
 
 You will need nothing but a web browser for this quickstart.
 


### PR DESCRIPTION
Starting from a fix in the Simple Search bullets which were lacking indention, this PR implements a cohesive styling of unordered lists in the docs. Be aware that the current styling renders the content in the bullet point above the indent point(s) as bold. Maybe we could/should change that?