### PR TITLE
Add asset override feature to docs

### DIFF
--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -203,9 +203,11 @@ SSL Zertifikat
 Für Produktivumgebungen ist die Installation eines SSL-Zertifikats wichtig. Anschließend muss die Variable ``parameters.cookie_secure`` in Ihrer ``parameters.yaml`` auf ``true`` gesetzt werden. Dadurch wird sichergestellt, dass das Login-Cookie nur über sichere Verbindungen übertragen wird.
 
 
+.. _override_js_css_yaml_de:
+
 Überschreiben von JavaScript- und CSS/Sass-Ressourcen
 *****************************************************
-Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :ref:`zu dieser Methode<override_js_css_de>` in Ihrer ``paramaters.yml``-Datei Folgendes hinzufügen:
+Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :ref:`zum Überschreiben im Bundle selbst<override_js_css_de>` in Ihrer ``paramaters.yaml``-Datei Folgendes hinzufügen:
 
 .. code-block:: yaml
 
@@ -213,7 +215,7 @@ Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :r
         "@MapbenderCoreBundle/Resources/public/sass/element/featureinfo.scss": "@@MyBundle/Resources/public/sass/element/custom_featureinfo.scss"
 
 
-.. note:: Beachten Sie, dass das `@`-Zeichen im Ersetzungsschlüssel durch ein weiteres `@@`-Zeichen escaped werden muss.
+.. note:: Beachten Sie, dass das `@`-Zeichen im Ersetzungsschlüssel durch ein weiteres `@@`-Zeichen maskiert werden muss.
 
 
 doctrine.yaml

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -202,6 +202,20 @@ SSL Zertifikat
 **************
 Für Produktivumgebungen ist die Installation eines SSL-Zertifikats wichtig. Anschließend muss die Variable ``parameters.cookie_secure`` in Ihrer ``parameters.yaml`` auf ``true`` gesetzt werden. Dadurch wird sichergestellt, dass das Login-Cookie nur über sichere Verbindungen übertragen wird.
 
+
+Überschreiben von JavaScript- und CSS/Sass-Ressourcen
+*****************************************************
+Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :ref:`zu dieser Methode<override_js_css_de>` in Ihrer ``paramaters.yml``-Datei Folgendes hinzufügen:
+
+.. code-block:: yaml
+
+    mapbender.asset_overrides:
+        "@MapbenderCoreBundle/Resources/public/sass/element/featureinfo.scss": "@@MyBundle/Resources/public/sass/element/custom_featureinfo.scss"
+
+
+.. note:: Beachten Sie, dass das `@`-Zeichen im Ersetzungsschlüssel durch ein weiteres `@@`-Zeichen escaped werden muss.
+
+
 doctrine.yaml
 -------------
 

--- a/de/development/introduction.rst
+++ b/de/development/introduction.rst
@@ -48,7 +48,7 @@ Nutzen Sie dazu ``mapbender.application_asset.service`` innerhalb einer Klasse, 
 Alternativ können Sie dieses Verhalten in einer beliebigen PHP-Datei mit ``<argument type="service" id="mapbender.application_asset.service" />`` erreichen. Stellen Sie bei dieser Methode wiederum sicher, dass Sie eine Datei verwenden, die aufgerufen wird (z.B. das Template).
 
 Rufen Sie anschließend ``ApplicationAssetService::registerAssetOverride`` oder ``ApplicationAssetService::registerAssetOverrides`` auf, um Assets für den Ersatz zu markieren.
-Anhand finden Sie ein Beispiel, welches eigene Ressourcen für die **Button**-Klasse nutzt:
+Nachfolgend finden Sie ein Beispiel, welches eigene Ressourcen für die **Button**-Klasse nutzt:
 
 .. code-block:: php
 
@@ -68,6 +68,9 @@ Anhand finden Sie ein Beispiel, welches eigene Ressourcen für die **Button**-Kl
          ]);
       }
    }
+
+
+.. hint:: Alternativ ist es möglich, Ressourcen mithilfe :ref:`eines Parameters<override_js_css_yaml_de>` zu überschreiben.
 
 
 Wo gibt es Hilfe?

--- a/de/development/introduction.rst
+++ b/de/development/introduction.rst
@@ -37,6 +37,37 @@ Sie kann verwendet werden, um ein Layout zu erstellen. Auf diese Weise kann ein 
 Lesen Sie mehr über Templates auf der Seite :ref:`templates_de` oder im `Contributing Guide <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md#generate-translations>`_. Eine Einführung in Twig gibt außerdem die `Symfony Template Dokumentation <https://symfony.com/doc/current/templates.html>`_.
 
 
+Überschreiben von JavaScript- und CSS/Sass-Ressourcen
+*****************************************************
+
+Unter Verwendung der ApplicationAssetService-Klasse sind JavaScript- und CSS/Sass-Ressourcen manuell überschreibbar:
+
+Nutzen Sie dazu ``mapbender.application_asset.service`` innerhalb einer Klasse, zum Beispiel in der `boot`-Methode Ihrer Bundle-Datei mit ``$this->container->get('mapbender.application_asset.service')``.
+Alternativ können Sie dieses Verhalten in einer beliebigen PHP-Datei mit ``<argument type="service" id="mapbender.application_asset.service" />`` erreichen. Stellen Sie bei dieser Methode wiederum sicher, dass Sie eine Datei verwenden, die aufgerufen wird (z.B. das Template).
+
+Rufen Sie anschließend ``ApplicationAssetService::registerAssetOverride`` oder ``ApplicationAssetService::registerAssetOverrides`` auf, um Assets für den Ersatz zu markieren.
+Anhand finden Sie ein Beispiel, welches eigene Ressourcen für die **Button**-Klasse nutzt:
+
+.. code-block:: php
+
+   class MyBundle extends Bundle
+   {
+      [ ... ]
+
+      public function boot(): void
+      {
+         parent::boot();
+         $assetService = $this->container->get('mapbender.application_asset.service');
+         $assetService->registerAssetOverride('@MapbenderCoreBundle/Resources/public/sass/element/button.scss', '@MyBundle/Resources/public/element/my_button.scss');
+
+         $assetService->registerAssetOverrides([
+               '@MapbenderCoreBundle/Resources/public/sass/element/button.scss' => '@MyBundle/Resources/public/sass/element/my_button.scss',
+               '@MapbenderCoreBundle/Resources/public/js/element/button.js' => '@MyBundle/Resources/public/js/element/my_button.js',
+         ]);
+      }
+   }
+
+
 Wo gibt es Hilfe?
 *****************
 

--- a/de/development/introduction.rst
+++ b/de/development/introduction.rst
@@ -37,6 +37,8 @@ Sie kann verwendet werden, um ein Layout zu erstellen. Auf diese Weise kann ein 
 Lesen Sie mehr über Templates auf der Seite :ref:`templates_de` oder im `Contributing Guide <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md#generate-translations>`_. Eine Einführung in Twig gibt außerdem die `Symfony Template Dokumentation <https://symfony.com/doc/current/templates.html>`_.
 
 
+.. _override_js_css_de:
+
 Überschreiben von JavaScript- und CSS/Sass-Ressourcen
 *****************************************************
 

--- a/de/faq.rst
+++ b/de/faq.rst
@@ -232,12 +232,12 @@ A: Möglichkeit 1 (über Git): Über die Konsole in das Verzeichnis application/
 Möglichkeit 2 (über Composer): "mapbender/mapbender": "dev-fix/meinfix" eintragen und ein Composer Update ausführen. Dabei werden aber auch alle anderen Vendor-Pakete aktualisiert. Rückgängig kann dies mit der Angabe des vorherigen Branches gemacht werden: Dazu erneut in application/mapbender gehen und den Branch auschecken.
 
 
-Überschreiben von Vorlagen
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Überschreiben von Twig-Dateien
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-F: Wie kann ich Vorlagen in Bundles überschreiben und auf diese Weise das Erscheinungsbild bestimmter Elemente in Mapbender anpassen?
+F: Wie kann ich Twig-Dateien in Bundles überschreiben und auf diese Weise das Design bestimmter Elemente anpassen?
 
-A: Um Vorlagen in Bundles zu überschreiben, legen Sie einfach eine Twig-Datei mit dem gleichen Namen im Verzeichnis `templates/bundles/<bundlename>` ab. Wenn Sie z.B. das Erscheinungsbild der Koordinatenanzeige anpassen möchten (zu finden unter `Resources/views/Element/coordinatesdisplay.html.twig` im Mapbender CoreBundle), erstellen Sie eine Ersatzdatei unter `templates/bundles/MapbenderCoreBundle/Element/coordinatesdisplay.html.twig`. Diese neue Datei wird anstelle der ursprünglichen verwendet.
+A: Um Twig-Dateien zu überschreiben, legen Sie einfach eine Twig-Datei mit dem gleichen Namen im Verzeichnis `templates/bundles/<bundlename>` ab. Wenn Sie z.B. das Erscheinungsbild der Koordinatenanzeige anpassen möchten (zu finden unter `Resources/views/Element/coordinatesdisplay.html.twig` im Mapbender CoreBundle), erstellen Sie eine Kopie, passen diese an und legen sie unter `templates/bundles/MapbenderCoreBundle/Element/coordinatesdisplay.html.twig` ab. Diese neue Datei wird anstelle der ursprünglichen verwendet.
 
 
 Oracle

--- a/de/faq.rst
+++ b/de/faq.rst
@@ -232,6 +232,14 @@ A: Möglichkeit 1 (über Git): Über die Konsole in das Verzeichnis application/
 Möglichkeit 2 (über Composer): "mapbender/mapbender": "dev-fix/meinfix" eintragen und ein Composer Update ausführen. Dabei werden aber auch alle anderen Vendor-Pakete aktualisiert. Rückgängig kann dies mit der Angabe des vorherigen Branches gemacht werden: Dazu erneut in application/mapbender gehen und den Branch auschecken.
 
 
+Überschreiben von Vorlagen
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+F: Wie kann ich Vorlagen in Bundles überschreiben und auf diese Weise das Erscheinungsbild bestimmter Elemente in Mapbender anpassen?
+
+A: Um Vorlagen in Bundles zu überschreiben, legen Sie einfach eine Twig-Datei mit dem gleichen Namen im Verzeichnis `templates/bundles/<bundlename>` ab. Wenn Sie z.B. das Erscheinungsbild der Koordinatenanzeige anpassen möchten (zu finden unter `Resources/views/Element/coordinatesdisplay.html.twig` im Mapbender CoreBundle), erstellen Sie eine Ersatzdatei unter `templates/bundles/MapbenderCoreBundle/Element/coordinatesdisplay.html.twig`. Diese neue Datei wird anstelle der ursprünglichen verwendet.
+
+
 Oracle
 ------
 

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -205,9 +205,11 @@ SSL certificate
 For productive environments, it is important to install a SSL certificate. After that, set the ``parameters.cookie_secure`` variable in your ``parameters.yaml`` to ``true``. This ensures that the Login cookie is only transmitted over secure connections.
 
 
+.. _override_js_css_yaml:
+
 Overriding JavaScript and CSS/Sass Resources
 ********************************************
-To manually override JavaScript and CSS/Sass resources, and as an alternative to :ref:`this method <override_js_css>`, you can add the following to your ``paramaters.yml`` file:
+To manually override JavaScript and CSS/Sass resources, and as an alternative to :ref:`overriding in the bundle <override_js_css>`, you can add the following to your ``paramaters.yaml`` file:
 
 .. code-block:: yaml
     

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -199,9 +199,23 @@ Configuration example:
         ows_proxy3_noproxy:                   # list of hosts for connnections without proxy server
             - 192.168.1.123
 
+
 SSL certificate
 ***************
 For productive environments, it is important to install a SSL certificate. After that, set the ``parameters.cookie_secure`` variable in your ``parameters.yaml`` to ``true``. This ensures that the Login cookie is only transmitted over secure connections.
+
+
+Overriding JavaScript and CSS/Sass Resources
+********************************************
+To manually override JavaScript and CSS/Sass resources, and as an alternative to :ref:`this method <override_js_css>`, you can add the following to your ``paramaters.yml`` file:
+
+.. code-block:: yaml
+    
+    mapbender.asset_overrides:
+        "@MapbenderCoreBundle/Resources/public/sass/element/featureinfo.scss": "@@MyBundle/Resources/public/sass/element/custom_featureinfo.scss"
+
+
+.. note:: Please note that the @ sign in the replacement key must be escaped with an additional @@ sign.
 
 
 doctrine.yaml

--- a/en/development/introduction.rst
+++ b/en/development/introduction.rst
@@ -37,6 +37,37 @@ You can use them to create a layout. You can create a base layout and then overw
 Read more about Templates in Mapbender at :ref:`templates` or in the `Contributing Guide <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md#generate-translations>`_ and find a good introduction about Twig in the `Symfony Template documentation <https://symfony.com/doc/current/templates.html>`_.
 
 
+Overriding JavaScript and CSS/Sass Resources
+********************************************
+
+Using the ApplicationAssetService class, JavaScript and CSS/Sass resources can be manually overridden:
+
+To do this, use ``mapbender.application_asset.service`` within a class, e.g., in the `boot` method of your bundle file with ``$this->container->get('mapbender.application_asset.service')``.
+Alternatively, you can achieve this behavior in any PHP file with ``<argument type="service" id="mapbender.application_asset.service" />``. Make sure to use a file that gets called, such as the template.
+
+Then, call ``ApplicationAssetService::registerAssetOverride`` or ``ApplicationAssetService::registerAssetOverrides`` to mark assets for replacement.
+Below you will find an example that utilizes custom resources for the **Button** class:
+
+.. code-block:: php
+
+   class MyBundle extends Bundle
+   {
+      [ ... ]
+
+      public function boot(): void
+      {
+         parent::boot();
+         $assetService = $this->container->get('mapbender.application_asset.service');
+         $assetService->registerAssetOverride('@MapbenderCoreBundle/Resources/public/sass/element/button.scss', '@MyBundle/Resources/public/element/my_button.scss');
+
+         $assetService->registerAssetOverrides([
+               '@MapbenderCoreBundle/Resources/public/sass/element/button.scss' => '@MyBundle/Resources/public/sass/element/my_button.scss',
+               '@MapbenderCoreBundle/Resources/public/js/element/button.js' => '@MyBundle/Resources/public/js/element/my_button.js',
+         ]);
+      }
+   }
+
+
 Getting Help
 ************
 

--- a/en/development/introduction.rst
+++ b/en/development/introduction.rst
@@ -69,6 +69,7 @@ Below you will find an example that utilizes custom resources for the **Button**
       }
    }
 
+.. hint:: It is also possible to override a resource :ref:`in the parameters.yaml file<override_js_css_yaml>`.
 
 Getting Help
 ************

--- a/en/development/introduction.rst
+++ b/en/development/introduction.rst
@@ -37,6 +37,8 @@ You can use them to create a layout. You can create a base layout and then overw
 Read more about Templates in Mapbender at :ref:`templates` or in the `Contributing Guide <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md#generate-translations>`_ and find a good introduction about Twig in the `Symfony Template documentation <https://symfony.com/doc/current/templates.html>`_.
 
 
+.. _override_js_css:
+
 Overriding JavaScript and CSS/Sass Resources
 ********************************************
 

--- a/en/faq.rst
+++ b/en/faq.rst
@@ -234,12 +234,12 @@ A: Alternative 1 (via Git): Go in the directory application/mapbender and checko
 Alternative 2 (via Composer): Change the entry in composer: "mapbender/mapbender": "dev-fix/meinfix" and do a Composer Update. Keep in mind that with that step all other vendor packages will be updated. To go back, specify the original branch. In addition go back to application/mapbender and checkout the original branch.
 
 
-Overriding Templates
-~~~~~~~~~~~~~~~~~~~
+Overriding twig templates
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Q: What is the process for overriding templates in bundles, and how can I customize the appearance of specific elements in Mapbender?
+Q: What is the process for overriding twig templates in bundles, and how can I customize the design of specific elements in Mapbender?
 
-A: Templates within bundles can be overridden by placing a twig file with the same name in `templates/bundles/<bundlename>`.
+A: Twig templates within bundles can be overridden by placing a twig file with the same name in `templates/bundles/<bundlename>`.
 If, for example, you want to customise the coordinates display (`Resources/views/Element/coordinatesdisplay.html.twig` within the Mapbender CoreBundle), place a replacement file in `templates/bundles/MapbenderCoreBundle/Element/coordinatesdisplay.html.twig`. The new file will be used instead of the original one.
 
 

--- a/en/faq.rst
+++ b/en/faq.rst
@@ -234,6 +234,15 @@ A: Alternative 1 (via Git): Go in the directory application/mapbender and checko
 Alternative 2 (via Composer): Change the entry in composer: "mapbender/mapbender": "dev-fix/meinfix" and do a Composer Update. Keep in mind that with that step all other vendor packages will be updated. To go back, specify the original branch. In addition go back to application/mapbender and checkout the original branch.
 
 
+Overriding Templates
+~~~~~~~~~~~~~~~~~~~
+
+Q: What is the process for overriding templates in bundles, and how can I customize the appearance of specific elements in Mapbender?
+
+A: Templates within bundles can be overridden by placing a twig file with the same name in `templates/bundles/<bundlename>`.
+If, for example, you want to customise the coordinates display (`Resources/views/Element/coordinatesdisplay.html.twig` within the Mapbender CoreBundle), place a replacement file in `templates/bundles/MapbenderCoreBundle/Element/coordinatesdisplay.html.twig`. The new file will be used instead of the original one.
+
+
 Oracle
 ------
 


### PR DESCRIPTION
Divided the text submitted in [this PR](https://github.com/mapbender/mapbender/pull/1512) into three different doc pages:

- faq.rst: Add a general section on how to override templates in FAQ format.
- introduction.rst (of development chapter): Add option 1 - how to use the ApplicationAssetService class.
- yaml.rst: Add option 2 - use of configuration file in parameters.yaml. 

This PR fulfills #409 .