### PR TITLE
Add sphinx.ext.autosectionlabel for easy citation of headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,13 @@ Below you'll find some basic conventions about documentation writing.
 
 ### Crosslinks
 
-Create crosslinks to refer to another documentation page with a label. Labels that refer to a page are always in the first line of the file. Feel free to add labels above headings, if you want to refer to these instead.
+We use the [Sphinx Autosectionlabel extension](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html) for referencing sections using the title of a section. The syntax is to combine the file path name, followed by a colon, followed by the section title name.
+
+For example, you can add a link to the Install Mapbender section of the english Quickstart document like this:
 
 ```bash
-    .. _activity_indicator:
+    The following class refers to the :ref:`en/quickstart:Install Mapbender` text section.
 ```
-
-Add the crosslink to your documentation text section like this:
-
-```bash
-    After this text is a link to :ref:`activity_indicator`.
-```
-
-Note that German labels always use the `_de` suffix.
 
 ### Images (figures)
 

--- a/conf.py
+++ b/conf.py
@@ -19,13 +19,18 @@ needs_sphinx = '1.8'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
+    'sphinx.ext.duration',
+    'sphinx.ext.coverage',
+    'sphinx.ext.todo',
     'notfound.extension',
     'sphinx_copybutton',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
     'sphinxcontrib.phpdomain'
 ]
+
+# Create unique sections for duplicate headings with autosectionlabel extension.
+autosectionlabel_prefix_document = True
 
 # -- notfound.extension
 notfound_template = "404.html"

--- a/de/backend/applications/layerset.rst
+++ b/de/backend/applications/layerset.rst
@@ -70,13 +70,13 @@ Der Screenshot zeigt die `private Instanz <#freie-und-private-instanzen>`_ ``2/2
 
 - **Sichtbarkeit:** Der Dienst kann mit dieser Schaltfläche sichtbar geschaltet werden.
 
-- **BaseSource:** Der Dienst soll als BaseSource (Basisdienst) behandelt werden. Dies hat Auswirkungen auf den :ref:`basesourceswitcher_de`, der nur BaseSources anzeigen soll und auf den :ref:`layertree_de`, in dem diese BaseSources dann auch ausgeblendet werden können. Siehe auch unter `Hinweise <hinweise-layersets_>`_.
+- **BaseSource:** Der Dienst soll als BaseSource (Basisdienst) behandelt werden. Dies hat Auswirkungen auf den :ref:`basesourceswitcher_de`, der nur BaseSources anzeigen soll und auf den :ref:`layertree_de`, in dem diese BaseSources dann auch ausgeblendet werden können. Siehe auch unter :ref:`Hinweise <de/backend/applications/layerset:Hinweise zu den Auswirkungen der einzelnen Konfigurationen>`.
 
-- **Proxy:** Bei Aktivierung wird der Dienst über Mapbender als Proxy angefordert. Siehe auch unter `Hinweise <hinweise-layersets_>`.
+- **Proxy:** Bei Aktivierung wird der Dienst über Mapbender als Proxy angefordert. Siehe auch unter :ref:`Hinweise <de/backend/applications/layerset:Hinweise zu den Auswirkungen der einzelnen Konfigurationen>`.
 
 - **Transparenz:** Ist dieser Schalter aktiviert (und das ist er standardmäßig) wird der Dienst mit transparentem Hintergrund angefordert. Also im WMS GetMap-Request mit dem Parameter ``TRANSPARENT=TRUE``.
 
-- **Gekachelt (Tiled):** Der Dienst wird in Kacheln angefordert (Standard: nicht gekachelt). Siehe auch unter `Hinweise <hinweise-layersets_>`.
+- **Gekachelt (Tiled):** Der Dienst wird in Kacheln angefordert (Standard: nicht gekachelt). Siehe auch unter :ref:`Hinweise <de/backend/applications/layerset:Hinweise zu den Auswirkungen der einzelnen Konfigurationen>`.
 
 
 **Layer-Reihenfolge:**
@@ -137,8 +137,6 @@ Zu einer Übersicht aller freien Instanzen kann über das Menü zu **Datenquelle
 .. image:: ../../../figures/de/layerset/shared_instances_overview.png
 
 
-.. _layer_konfiguration:
-
 Layerkonfiguration
 ==================
 
@@ -161,7 +159,6 @@ Layerkonfiguration
 * **Name**: Layername der Service Information (wird beim getMap-Request verwendet und ist nicht veränderbar).
 * **Style**: Wenn ein WMS mehr als einen Stil anbietet, können Sie einen anderen Stil als den Standard-Stil wählen.
 
-.. _hinweise-layersets:
 
 Hinweise zu den Auswirkungen der einzelnen Konfigurationen
 ==========================================================

--- a/de/backend/sources.rst
+++ b/de/backend/sources.rst
@@ -5,7 +5,7 @@ Datenquellen (Sources)
 
 Über den Backend-Menübereich Datenquellen können OGC WMS- und WMTS/TMS-Dienste in den Versionen 1.1.1 und 1.3.0 registriert werden.
 
-Informationen zum Einbinden von Diensten und die Nutzung in Anwendungen finden Sie im Schnellstart-Kapitel :ref:`load_sources_de`.
+Informationen zum Einbinden von Diensten und die Nutzung in Anwendungen finden Sie im Schnellstart-Kapitel :ref:`de/quickstart:Laden von Datenquellen`.
 
 
 Datenquelle laden

--- a/de/customization/commands.rst
+++ b/de/customization/commands.rst
@@ -13,7 +13,6 @@ Achten Sie beim Ausführen der Befehle darauf, dass Sie sich im richtigen Verzei
 
 * mapbender (bei der Paketinstallation)
 
-.. _app_command_help_de:
 
 Hilfe zu den Befehlen
 ---------------------
@@ -24,8 +23,6 @@ Die Hilfe für jeden Befehl kann mit dem ``--help`` Parameter aufgerufen werden,
 
     bin/console mapbender:user:create --help
    
-
-.. _app_command_export_import_clone_de:
 
 Anwendungs-Export, Import und Klonen
 ------------------------------------
@@ -211,7 +208,7 @@ Der Druck in der Warteschlange ist standardmäßig deaktiviert, da er eine exter
 
 	mapbender.print.queueable: true
 
-Weitere Informationen zum Warteschleifendruck gibt es im Kapitel :ref:`queued_print_de` sowie auf `GitHub <https://github.com/mapbender/mapbender/pull/1070>`_.
+Weitere Informationen zum Warteschleifendruck gibt es im Kapitel :ref:`de/elements/export/printclient:Warteschleifendruck` sowie auf `GitHub <https://github.com/mapbender/mapbender/pull/1070>`_.
 
 Anschließend wird im Backend des Mapbenders der Druckassistent aktualisiert und es erscheinen zwei neue Zeilen, Modus und Warteschleife.
 
@@ -582,7 +579,7 @@ Aktualisiert den Hostnamen in den Quell-URLs, ohne die Funktionen/Capabilities n
 
     bin/console mapbender:source:rewrite:host [options] [--] <from> <to>
 
-Vergessen Sie nicht, dass Sie sich auch hier weitere Optionen über :ref:`app_command_help_de` anzeigen lassen können.
+Vergessen Sie nicht, dass Sie sich auch hier weitere Optionen über :ref:`de/customization/commands:Hilfe zu den Befehlen` anzeigen lassen können.
 
 Umsetzungsbeispiel für die Aktualisierung eines Hostnamens:
 
@@ -597,10 +594,8 @@ Umsetzungsbeispiel für die Aktualisierung eines Hostnamens:
 	4 sources unchanged
 	14 urls unchanged
    
-    
-.. _mapbender_config_check_de:
 
-bin/console mapbender:config:check 
+bin/console mapbender:config:check
 **********************************
 
 Der Befehl prüft die Konfiguration und gibt zur Information die Systemkonfiguration aus. Dadurch kann ermittelt werden, ob Abhängigkeiten nicht erfüllt werden.

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -11,8 +11,9 @@ parameters.yaml
 Hier werden grundlegende Parameter von Mapbender bestimmt.
 
 
-Datenbank
-*********
+Datenbank-Konfiguration
+***********************
+
 Zur Konfiguration der Datenbankverbindung werden die Dateien ``parameters.yaml`` und ``doctrine.yaml`` verwendet. In der ``parameters.yaml`` werden Variablen für die Datenbankverbindung definiert. Es können mehrere Datenbankverbindungen definiert werden. Die Variablen werden in der ``doctrine.yaml`` verarbeitet. Zu jeder Datenbankverbindung wird ein Alias vergeben.
 
 * **database_driver**: Der Datenbanktreiber. Mögliche Werte sind:
@@ -94,8 +95,6 @@ Es kann ein Disclaimer mittels Sitelinks hinzugefügt werden. Dafür muss Folgen
 
 Die Sitelinks werden mittels "|" voneinander getrennt.
 
-
-.. _custom-icons_de:
 
 Icons anpassen
 **************
@@ -243,11 +242,9 @@ SSL Zertifikat
 Für Produktivumgebungen ist die Installation eines SSL-Zertifikats wichtig. Anschließend muss die Variable ``parameters.cookie_secure`` in Ihrer ``parameters.yaml`` auf ``true`` gesetzt werden. Dadurch wird sichergestellt, dass das Login-Cookie nur über sichere Verbindungen übertragen wird.
 
 
-.. _override_js_css_yaml_de:
-
 Überschreiben von JavaScript- und CSS/Sass-Ressourcen
 *****************************************************
-Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :ref:`zum Überschreiben im Bundle selbst<override_js_css_de>` in Ihrer ``paramaters.yaml``-Datei Folgendes hinzufügen:
+Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :ref:`zum Überschreiben im Bundle selbst<de/development/introduction:Überschreiben von JavaScript- und CSS/Sass-Ressourcen>` in Ihrer ``paramaters.yaml``-Datei Folgendes hinzufügen:
 
 .. code-block:: yaml
 
@@ -267,9 +264,11 @@ Diese Datei enthält grundlegende Architektur-Vorgaben von Mapbender. Gleichzeit
 * **fom_user.reset_password**: Über diesen Parameter kann die Möglichkeit de/aktiviert werden, das Passwort neu zu setzen.
 * **framework.session.cookie_httponly**: Stellen Sie für HTTP-only session cookies sicher, dass der Parameter framework.session.cookie_httponly auf true steht.
 
-Datenbank
-*********
-Wichtig: Jede Datenbank, die in der ``parameters.yaml`` definiert wird, muss auch als Platzhalter in der ``doctrine.yaml`` stehen:
+
+Datenbank-Platzhalter
+*********************
+
+.. note:: Jede Datenbank, die in der ``parameters.yaml`` definiert wird, muss auch als Platzhalter in der ``doctrine.yaml`` stehen:
 
 .. code-block:: yaml
 
@@ -291,7 +290,9 @@ Wichtig: Jede Datenbank, die in der ``parameters.yaml`` definiert wird, muss auc
                 profiling: "%kernel.debug%"                 # Profiling von SQL Anfragen. Diese Option kann in der Produktion ausgeschaltet werden. (Standard: %kernel.debug%)
                 #server_version: '15'                       # Wichtig: Sie MÜSSEN die Serverversion konfigurieren, entweder hier oder in der DATABASE_URL Umgebungsvariable (siehe .env-Datei).
 
-**Verwendung mehrerer Datenbanken**
+
+Verwendung mehrerer Datenbanken (doctrine.yaml)
+***********************************************
 
 Es folgt ein Beispiel mit zwei Datenbankverbindungen in der **doctrine.yaml**:
 
@@ -410,7 +411,7 @@ Nutzen Sie danach die abgebildete Maske, um eine Importdatei als Anwendung zu la
 Export/Import/Klonen von YAML Anwendungsdateien über die Konsole
 ----------------------------------------------------------------
 
-Bitte gehen Sie zu :ref:`app_command_export_import_clone_de`, um entsprechende Konsolenbefehle einzusehen. Nachfolgend finden Sie einige einführende Worte darüber, was mit Anwendungen über die Konsole möglich ist.
+Bitte gehen Sie zu :ref:`de/customization/commands:Anwendungs-Export, Import und Klonen`, um entsprechende Konsolenbefehle einzusehen. Nachfolgend finden Sie einige einführende Worte darüber, was mit Anwendungen über die Konsole möglich ist.
 
 **Export über die Konsole**
 

--- a/de/development/introduction.rst
+++ b/de/development/introduction.rst
@@ -37,8 +37,6 @@ Sie kann verwendet werden, um ein Layout zu erstellen. Auf diese Weise kann ein 
 Lesen Sie mehr über Templates auf der Seite :ref:`templates_de` oder im `Contributing Guide <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md#generate-translations>`_. Eine Einführung in Twig gibt außerdem die `Symfony Template Dokumentation <https://symfony.com/doc/current/templates.html>`_.
 
 
-.. _override_js_css_de:
-
 Überschreiben von JavaScript- und CSS/Sass-Ressourcen
 *****************************************************
 
@@ -70,7 +68,7 @@ Nachfolgend finden Sie ein Beispiel, welches eigene Ressourcen für die **Button
    }
 
 
-.. hint:: Alternativ ist es möglich, Ressourcen mithilfe :ref:`eines Parameters<override_js_css_yaml_de>` zu überschreiben.
+.. hint:: Alternativ ist es möglich, Ressourcen mithilfe :ref:`eines Parameters<de/customization/yaml:Überschreiben von JavaScript- und CSS/Sass-Ressourcen>` zu überschreiben.
 
 
 Wo gibt es Hilfe?

--- a/de/elements/basic/map.rst
+++ b/de/elements/basic/map.rst
@@ -80,8 +80,6 @@ Diese Vorlage kann genutzt werden, um die Karte in einer YAML-Anwendung einzubin
 Kontrolle über URL-Parameter
 ============================
 
-.. _layer_visibility_de:
-
 Ebenen sichtbar machen
 ----------------------
 

--- a/de/elements/editing/datamanager.rst
+++ b/de/elements/editing/datamanager.rst
@@ -21,7 +21,7 @@ Die Definition des Data Managers erfolgt im YAML-Syntax.
 Hier definieren Sie die Datenbankverbindung, die editierbaren Felder, den Formularaufbau.
 
 
-.. hint:: Bei fehlerhaften Angaben zur Datenbank, Feldern und Formularfehlern erscheinen Fehlermeldungen. Bei Produktivumgebungen erscheint eine allgemeine Fehlermeldung. Falls Sie die detaillierte Fehlermeldung sehen möchten, sollten Sie die Anwendung als Entwicklungsumgebung aufrufen. Weitergehende Informationen unter :ref:`environments_de`.
+.. hint:: Bei fehlerhaften Angaben zur Datenbank, Feldern und Formularfehlern erscheinen Fehlermeldungen. Bei Produktivumgebungen erscheint eine allgemeine Fehlermeldung. Falls Sie die detaillierte Fehlermeldung sehen möchten, sollten Sie die Anwendung als Entwicklungsumgebung aufrufen. Weitergehende Informationen unter :ref:`de/quickstart:Starten von Mapbender als Produktivumgebung`.
 
 
 Der Data Manager kann beispielsweise genutzt werden, um Kontaktinformationen zu speichern.

--- a/de/elements/editing/digitizer/digitizer_configuration.rst
+++ b/de/elements/editing/digitizer/digitizer_configuration.rst
@@ -18,7 +18,7 @@ Mehr zu diesem Thema finden Sie unter :ref:`yaml_de`.
 
 Die Definition des Digitizers wird in einer YAML-Syntax durchgeführt. Hier definieren Sie die Datenbankverbindung, die editierbaren Felder, das Formular für die Anzeige und andere Verhaltensweisen.
 
-.. hint:: Bei fehlerhaften Angaben zur Datenbank, Feldern und Formularfehlern erscheinen Fehlermeldungen. Bei Produktivumgebungen erscheint eine allgemeine Fehlermeldung. Falls Sie die detaillierte Fehlermeldung sehen möchten, sollten Sie die Anwendung als Entwicklungsumgebung aufrufen. Weitergehende Informationen unter :ref:`environments_de`.
+.. hint:: Bei fehlerhaften Angaben zur Datenbank, Feldern und Formularfehlern erscheinen Fehlermeldungen. Bei Produktivumgebungen erscheint eine allgemeine Fehlermeldung. Falls Sie die detaillierte Fehlermeldung sehen möchten, sollten Sie die Anwendung als Entwicklungsumgebung aufrufen. Weitergehende Informationen unter :ref:`de/quickstart:Starten von Mapbender als Produktivumgebung`.
 
 
 YAML-Definition für das Element digitizer in der Textarea unter schemes

--- a/de/elements/export/printclient.rst
+++ b/de/elements/export/printclient.rst
@@ -346,10 +346,8 @@ Mit Klick auf den Druckbutton, öffnet sich ein Druckdialog, der das definierte 
 
 Das gewünschte Gebiet kann auswählt werden und ein PDF erzeugt. Das PDF beinhaltet die Informationen für das selektierte Objekt.
 
-Bemerkung: Die Flexibilität, den Druckrahmen zu verschieben, hindert den Anwender nicht daran, den Rahmen in einen Bereich zu verschieben, der nicht das ausgewählte Objekt enthält. Die ausgedruckte Objektinformation passt dann nicht zur Darstellung in der Karte.
+.. note:: Die Flexibilität, den Druckrahmen zu verschieben, hindert den Anwender nicht daran, den Rahmen in einen Bereich zu verschieben, der nicht das ausgewählte Objekt enthält. Die ausgedruckte Objektinformation passt dann nicht zur Darstellung in der Karte.
 
-
-.. _queued_print_de:
   
 Warteschleifendruck
 -------------------

--- a/de/elements/misc/button.rst
+++ b/de/elements/misc/button.rst
@@ -32,7 +32,7 @@ Für einige Symbole können zwei verschiedene Icon-Typen ausgewählt werden.
 
 Letztere basieren auf einem `IconSet <https://github.com/mapbender/icons>`_, das mit dem Mapbender als Modul ausgeliefert wird. Wir empfehlen die Verwendung der Symbole aus dieser Bibliothek.
 
-.. hint:: Es ist auch möglich, ein Icon-Set zu deaktivieren und/oder andere Icons zu verwenden. Weitere Informationen finden Sie unter :ref:`custom-icons_de`.
+.. hint:: Es ist auch möglich, ein Icon-Set zu deaktivieren und/oder andere Icons zu verwenden. Weitere Informationen finden Sie unter :ref:`de/customization/yaml:Icons anpassen`.
 
 Mehr Informationen zu Icons unter:
 

--- a/de/elements/misc/link.rst
+++ b/de/elements/misc/link.rst
@@ -28,7 +28,7 @@ Für einige Symbole können zwei verschiedene Icon-Typen ausgewählt werden.
 
 Letztere basieren auf einem `IconSet <https://github.com/mapbender/icons>`_, das mit dem Mapbender als Modul ausgeliefert wird. Wir empfehlen die Verwendung der Symbole aus dieser Bibliothek.
 
-.. hint:: Es ist auch möglich, ein Icon-Set zu deaktivieren und/oder andere Icons zu verwenden. Weitere Informationen finden Sie unter :ref:`custom-icons_de`.
+.. hint:: Es ist auch möglich, ein Icon-Set zu deaktivieren und/oder andere Icons zu verwenden. Weitere Informationen finden Sie unter :ref:`de/customization/yaml:Icons anpassen`.
 
 Mehr Informationen zu Icons unter:
 

--- a/de/faq.rst
+++ b/de/faq.rst
@@ -13,7 +13,7 @@ F: Wozu sind diese Umgebungen da?
 
 A: Für den produktiven Einsatz rufen Sie Mapbender über die `prod`-Umgebung auf. Erst wenn Sie selbst etwas (an den Twig-, CSS- oder JS-Dateien) entwickeln, nutzen Sie den Aufruf über die `dev`-Umgebung. Der dahinterstehende Entwicklungsmodus gibt mehr Informationen aus, indem er z. B. detailliertere Fehlermeldungen anzeigt. 
 
-Mehr Details zu den Umgebungen gibt es im Kapitel :ref:`environments_de`.
+Mehr Details zu den Umgebungen gibt es im Kapitel :ref:`de/quickstart:Starten von Mapbender als Produktivumgebung`.
 
 
 Cache
@@ -25,7 +25,7 @@ A: Der Cache ist ein Zwischenspeicher, aus dem Mapbender auf häufig benutzte Da
 
 Diese zwei Verzeichnisse können ohne Bedenken gelöscht werden. Beim nächsten Aufruf von Mapbender werden im Cache der entsprechenden Umgebung erneut Dateien abgelegt.
 
-Mehr Details zum Cache gibt es im Kapitel :ref:`app_cache_de`.
+Mehr Details zum Cache gibt es im Kapitel :ref:`de/installation/installation_configuration:Produktions- und Entwicklungsumgebung und Caches`.
 
 
 Dienste in Anwendungen

--- a/de/installation/installation_configuration.rst
+++ b/de/installation/installation_configuration.rst
@@ -124,8 +124,6 @@ Die Konfigurationsdateien liegen unter ``application/config``.
 Mehr Informationen dazu finden Sie im Kapitel: :ref:`yaml_de`.
 
 
-.. _app_cache_de:
-
 Produktions- und Entwicklungsumgebung und Caches
 ------------------------------------------------
 

--- a/de/installation/installation_ubuntu.rst
+++ b/de/installation/installation_ubuntu.rst
@@ -123,7 +123,6 @@ Zur Nutzung der optionalen LDAP-Anbindung wird zunächst die PHP-LDAP-Extension 
 
 .. note:: Zur Verwendung von LDAP muss im Anschluss außerdem das `LDAP-Bundle <https://github.com/mapbender/ldapBundle>`_ in Mapbender integriert werden. Weitere Anweisungen zur Einrichtung finden Sie in der README.md auf GitHub.
 
-.. _postgres_install_config_de:
 
 Mapbender Einrichtung auf PostgreSQL
 ++++++++++++++++++++++++++++++++++++
@@ -193,4 +192,4 @@ Abweichend von der PostgreSQL-Konfiguration müssen für MySQL folgende Paramete
                     database_driver:   pdo_mysql
                     database_port:     3306
 
-Nachfolgend muss die Datenbank initialisiert werden, siehe :ref:`postgres_install_config_de`.
+Nachfolgend muss die Datenbank initialisiert werden, siehe :ref:`de/installation/installation_ubuntu:Mapbender Einrichtung auf PostgreSQL`.

--- a/de/installation/installation_windows.rst
+++ b/de/installation/installation_windows.rst
@@ -200,7 +200,7 @@ Zur Überprüfung der Konfiguration dient der folgende Befehl:
 
 .. hint:: Bitte beachten Sie, dass der Befehl mapbender:config:check die PHP-CLI Version nutzt. Die Einstellungen der CLI-Version können sich von denen der Webserver PHP-Version unterscheiden. Nutzen Sie beispielsweise php -r 'phpinfo();' zur Ausgabe der PHP-Webserver Einstellungen.
 
-Weitere Informationen dazu finden Sie unter :ref:`mapbender_config_check_de`.
+Weitere Informationen dazu finden Sie unter :ref:`de/customization/commands:bin/console mapbender:config:check`.
 
 Glückwunsch! Mapbender wurde erfolgreich installiert.
 Informationen zu den ersten Schritten mit Mapbender finden sich im :ref:`Mapbender Schnellstart <quickstart_de>`.

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -63,8 +63,9 @@ Eine Mapbender Anwendung kann wie folgt aussehen:
   .. image:: ../figures/de/mapbender_basic_application.png
      :width: 100%
 
-Installation
-============
+
+Mapbender installieren
+======================
 
 Dieser Schnellstart erklärt die Mapbender-Grundlagen nach erfolgter Installation und bietet einen schnellen Einstieg in die Mapbender-Oberfläche. Hinweise zur Installation von Mapbender finden Sie unter :ref:`installation_de`.
 
@@ -78,8 +79,6 @@ Dieser Schnellstart erklärt die Mapbender-Grundlagen nach erfolgter Installatio
 
 Falls Sie Schwierigkeiten haben Mapbender zu starten, überprüfen Sie, ob der Apache Web Server und die PostgreSQL-Datenbank korrekt funktionieren.
 
-
-.. _environments_de:
 
 Starten von Mapbender als Produktivumgebung
 -------------------------------------------
@@ -241,8 +240,6 @@ Die Übersichtsseite bietet dem Nutzer folgende Funktionen:
      :width: 100%
 
 
-.. _load_sources_de:
-
 Laden von Datenquellen
 ----------------------
 
@@ -353,7 +350,7 @@ Momentan eignet sich das Element, um Benutzer und Gruppeninformationen weiterzug
 * Aufklappen erlauben: Erlaubt Aufklappen des Layers im Ebenenbaum
 * Aufklappen an: Klappt Layer beim Start der Anwendung auf
 * Weitere Informationen (Drei-Punkte-Button): Öffnet einen Dialog mit weiteren Layer-Informationen
-    * ID: ID des Layers. Nützlich etwa, um URL-Parameter :ref:`zu kontrollieren <layer_visibility_de>`.
+    * ID: ID des Layers. Nützlich etwa, um URL-Parameter :ref:`zu kontrollieren <de/elements/basic/map:Ebenen sichtbar machen>`.
     * Name: Layername der Service Information (wird beim getMap-Request verwendet und ist nicht veränderbar)
     * Style: Wenn ein WMS mehr als einen Stil anbietet, können Sie einen anderen Stil als den Standard-Stil (default) wählen.
 

--- a/en/backend/applications/layerset.rst
+++ b/en/backend/applications/layerset.rst
@@ -72,13 +72,13 @@ The screenshot above shows the `bound instance <#shared-and-bound-instances>`_ `
 
 - **Visible:** The service can be set visible with this option.
 
-- **BaseSource:** The service should be treated as a BaseSource. This affects the :ref:`BaseSourceSwitcher <basesourceswitcher>`, which should only display BaseSources, and the :ref:`Layertree <layertree>`, where these BaseSources can be hidden. See also the `hints <hints-layersets_>`_ below.
+- **BaseSource:** The service should be treated as a BaseSource. This affects the :ref:`BaseSourceSwitcher <basesourceswitcher>`, which should only display BaseSources, and the :ref:`Layertree <layertree>`, where these BaseSources can be hidden. See also the :ref:`hints <en/backend/applications/layerset:Notes on the effects of each configuration>` below.
 
-- **Proxy:** If activated, the service will be requested via a proxy in Mapbender. See the `hints <hints-layersets_>`_ below.
+- **Proxy:** If activated, the service will be requested via a proxy in Mapbender. See the :ref:`hints <en/backend/applications/layerset:Notes on the effects of each configuration>` below.
 
 - **Transparency:** If this switch is enabled (that is the default), the service is requested with a transparent background. So in the WMS GetMap request with the parameter ``TRANSPARENT=TRUE``.
 
-- **Tiled:** The service is requested in tiles. The standard is not tiled. See the following `hints <hints-layersets_>`_.
+- **Tiled:** The service is requested in tiles. The standard is not tiled. See the following :ref:`hints <en/backend/applications/layerset:Notes on the effects of each configuration>`.
 
 
 **Layer-Order:**
@@ -140,8 +140,6 @@ All shared instances can be viewed under **Sources** -> **Shared instances**.
 .. image:: ../../../figures/layerset/shared_instances_overview.png
 
 
-.. _layer_configuration:
-
 Layer Configuration
 ===================
 
@@ -165,8 +163,6 @@ The layer table offers several checkboxes and two scale visibility fields that a
 * **Layer's name**: Layer name of the service information (for getMap-Requests, not adjustable).
 * **Style**: If a WMS provides more than one style, you can choose a different style than the default style.
 
-
-.. _hints-layersets:
 
 Notes on the effects of each configuration
 ===========================================

--- a/en/backend/sources.rst
+++ b/en/backend/sources.rst
@@ -5,7 +5,7 @@ Sources
 
 With Sources, you can register OGC WMS and OGC WMTS/TMS services in version 1.1.1 and 1.3.0 in Mapbender.
 
-Further information about the registration process of services and their usage in applications is available in the Quickstart chapter :ref:`load_sources`.
+Further information about the registration process of services and their usage in applications is available in the Quickstart chapter :ref:`en/quickstart:Load sources`.
 
 
 Load sources

--- a/en/customization/commands.rst
+++ b/en/customization/commands.rst
@@ -13,7 +13,6 @@ Make sure you are in the correct directory (above the app directory)
 
 * mapbender (installation via package)
 
-.. _app_command_help:
    
 Help command
 ------------
@@ -24,8 +23,6 @@ The parameter ``--help`` displays the help message for every command, for exampl
 
     bin/console mapbender:user:create --help
    
-
-.. _app_command_export_import_clone:
 
 Application Export, Import & Cloning
 ------------------------------------
@@ -211,7 +208,7 @@ The queued print is disabled by default because it requires some external integr
 
 	mapbender.print.queueable: true
 
-Read more about the general characteristics of queued print at :ref:`queued_print`. Also `here <https://github.com/mapbender/mapbender/pull/1070>`_
+Read more about the general characteristics of queued print at :ref:`en/elements/export/printclient:Queued Print`. Also `here <https://github.com/mapbender/mapbender/pull/1070>`_
 
 
 The print assistant is then updated in the backend of Mapbender and two new lines appear: mode and queue. 
@@ -580,7 +577,7 @@ Use this command to update the hostname in the source URLs, eliminating the need
 
   bin/console mapbender:source:rewrite:host [options] [--] <from> <to>
 
-As usual, the :ref:`app_command_help` shows more options.
+As usual, the :ref:`en/customization/commands:Help command` shows more options.
 
 Example to update the hostname:
 
@@ -596,9 +593,7 @@ Example to update the hostname:
 	14 urls unchanged
 
 
-.. _mapbender_config_check:
-
-bin/console mapbender:config:check 
+bin/console mapbender:config:check
 **********************************
 
 Command to check the system configuration and mapbender requirements. Useful command to determine whether dependencies are compliant and database access works.

--- a/en/customization/templates.rst
+++ b/en/customization/templates.rst
@@ -10,9 +10,6 @@ To prevent overwriting your custom templates after an Mapbender upgrade you shou
 You can also change the style of your application with the built-in :ref:`CSS-Editor <css>`.
 
 
-How to create your own template?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 **Steps for including your templates:**
 
 * Create your own bundle
@@ -26,7 +23,6 @@ How to create your own template?
 To help you we prepared a Workshop/DemoBundle, which can be used not only for application templates, but also for customizing the administration interface. For the following steps, you can download the files with the following links:
 
 * https://github.com/mapbender/mapbender-workshop/tree/master
-
 
 
 Create your own bundle

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -11,8 +11,9 @@ parameters.yaml
 The following fundamental Mapbender parameters are specified here.
 
 
-Database
-********
+Database configuration
+**********************
+
 The files ``parameters.yaml`` and ``doctrine.yaml`` are needed to configure databases in Mapbender. In ``parameters.yaml``, (multiple) variables for database connection(s) can be defined. These variables are being processed in ``doctrine.yaml``. An alias is assigned to each database connection.
 
 * **database_driver**: Database driver. Possible values are:
@@ -94,8 +95,6 @@ A disclaimer can be added through the use of site links.
 
 Site links will be seperated by "|".
 
-
-.. _custom-icons:
 
 Customizing icons
 *****************
@@ -245,11 +244,9 @@ SSL certificate
 For productive environments, it is important to install a SSL certificate. After that, set the ``parameters.cookie_secure`` variable in your ``parameters.yaml`` to ``true``. This ensures that the Login cookie is only transmitted over secure connections.
 
 
-.. _override_js_css_yaml:
-
 Overriding JavaScript and CSS/Sass Resources
 ********************************************
-To manually override JavaScript and CSS/Sass resources, and as an alternative to :ref:`overriding in the bundle <override_js_css>`, you can add the following to your ``paramaters.yaml`` file:
+To manually override JavaScript and CSS/Sass resources, and as an alternative to :ref:`overriding in the bundle <en/development/introduction:Overriding JavaScript and CSS/Sass Resources>`, you can add the following to your ``paramaters.yaml`` file:
 
 .. code-block:: yaml
     
@@ -268,9 +265,10 @@ doctrine.yaml
 * **framework.session.cookie_httponly**: For HTTP-only session cookies, make sure the framework.session.cookie_httponly parameter is set to true.
 
 
-Database
-********
-Important: Every database defined in parameters.yaml needs to have a placeholder in ``doctrine.yaml`` as well:
+Database placeholder
+********************
+
+.. note:: Every database defined in ``parameters.yaml`` needs to have a placeholder in ``doctrine.yaml`` as well:
 
 .. code-block:: yaml
 
@@ -293,8 +291,8 @@ Important: Every database defined in parameters.yaml needs to have a placeholder
                 profiling: "%kernel.debug%"                 # Profiling SQL requests. This option can be turned of in production. (standard: %kernel.debug%)
 
 
-Use of several databases
-************************
+Several database placeholders
+*****************************
 Example with two database connections in ``doctrine.yaml``:
 
 .. code-block:: yaml
@@ -413,7 +411,7 @@ Then, use the Import mask to load an import file as an application.
 Export/import/clone YAML application files over the console
 -----------------------------------------------------------
 
-Please go to :ref:`app_command_export_import_clone` to see the console commands. Find a few introductional words about exporting and importing applications over the console below.
+Please go to :ref:`en/customization/commands:Application Export, Import & Cloning` to see the console commands. Find a few introductional words about exporting and importing applications over the console below.
 
 **Export**
 

--- a/en/development/controllers.rst
+++ b/en/development/controllers.rst
@@ -72,8 +72,8 @@ Mapbender Controllers
 *********************
 A Mapbender installation uses a particular set of controller classes and functions. This chapter will give a short list of these, so you can inspect them more easily.
 
-Frontend
-~~~~~~~~
+The Frontend
+~~~~~~~~~~~~
 The frontend is basically "the application" (or GUI as it has been called in Mapbender 2 - and even there this term was incorrect). Each application is routed to the ApplicationController class of the CoreBundle:
 
 .. code-block:: yaml
@@ -88,8 +88,8 @@ Elements of an application can provide Ajax endpoints for their client side widg
 
 **Note:** This controller calls the **httpAction** method if the element class and passes the $action parameter and returns the response given by that function. So for the real magic for element Ajax behaviour take a look at the httpAction method of the elements.
 
-Backend
-~~~~~~~
+The Backend
+~~~~~~~~~~~
 The backend is handled by the ManagerBundle, which provides (will provide) a consistent backend for managing all aspects of a Mapbender application: applications, layers, elements, users, settings.
 
 For each section an own controller class exists within this bundle:

--- a/en/development/introduction.rst
+++ b/en/development/introduction.rst
@@ -37,8 +37,6 @@ You can use them to create a layout. You can create a base layout and then overw
 Read more about Templates in Mapbender at :ref:`templates` or in the `Contributing Guide <https://github.com/mapbender/mapbender-starter/blob/master/CONTRIBUTING.md#generate-translations>`_ and find a good introduction about Twig in the `Symfony Template documentation <https://symfony.com/doc/current/templates.html>`_.
 
 
-.. _override_js_css:
-
 Overriding JavaScript and CSS/Sass Resources
 ********************************************
 
@@ -69,7 +67,7 @@ Below you will find an example that utilizes custom resources for the **Button**
       }
    }
 
-.. hint:: It is also possible to override a resource :ref:`in the parameters.yaml file<override_js_css_yaml>`.
+.. hint:: It is also possible to override a resource :ref:`in the parameters.yaml file<en/customization/yaml:Overriding JavaScript and CSS/Sass Resources>`.
 
 Getting Help
 ************

--- a/en/elements/basic/map.rst
+++ b/en/elements/basic/map.rst
@@ -80,8 +80,6 @@ This template can be used to include the map into a YAML application.
 Controlling by URL-parameters
 =============================
 
-.. _layer_visibility:
-
 Make Layer visible
 ------------------
 

--- a/en/elements/editing/datamanager.rst
+++ b/en/elements/editing/datamanager.rst
@@ -20,7 +20,7 @@ Configuration example
 
 The definition of the Data Manager is done in YAML syntax in the textarea configuration at schemes. Here you define the database connection, the editable table, the attribute form.
 
-.. hint:: If errors occur in the database, fields or form, various error messages will appear. Here, the productive environment will only give a general error message. If you want to see the exact error, you should call the page as development environment. Find more under :ref:`environments`.
+.. hint:: If errors occur in the database, fields or form, various error messages will appear. Here, the productive environment will only give a general error message. If you want to see the exact error, you should call the page as development environment. Find more under en/quickstart:Start Mapbender in a productive environment.
 
 Data Manager is a good solution to store simple contact information in Mapbender:
 

--- a/en/elements/editing/digitizer/digitizer_configuration.rst
+++ b/en/elements/editing/digitizer/digitizer_configuration.rst
@@ -18,7 +18,7 @@ Read more about this under :ref:`yaml`.
 
 The definition of the Digitizer is done in YAML syntax in the textarea configuration at schemes. Here you define the database connection, the editable table, the form to display the table, the attribute form and other behavior.
 
-.. hint:: If errors occur in the database, fields or form, various error messages will appear. Here, the productive environment will only give a general error message. If you want to see the exact error, you should call the page as development environment. Find more under :ref:`environments`.
+.. hint:: If errors occur in the database, fields or form, various error messages will appear. Here, the productive environment will only give a general error message. If you want to see the exact error, you should call the page as development environment. Find more under en/quickstart:Start Mapbender in a productive environment.
 
 
 * **debug:** Display error messages, e.g. syntax error in SQL [experimental]

--- a/en/elements/export/printclient.rst
+++ b/en/elements/export/printclient.rst
@@ -334,8 +334,6 @@ With click on the print button the print dialog opens and offers the print templ
 .. note:: The flexibility to move the print frame won‘t stop you from choosing a region that does not contain the feature that was selected. In this case, the feature information does not match to the features that are displayed.
 
 
-.. _queued_print:
-
 Queued Print
 ------------
 

--- a/en/elements/misc/button.rst
+++ b/en/elements/misc/button.rst
@@ -31,7 +31,7 @@ For some symbols you can choose between two different types of icons:
 
 The latter are based on a `IconSet <https://github.com/mapbender/icons>`_, which is delivered with Mapbender as a module. We recommend to use the symbols from this library.
 
-.. hint:: It is also possible to deactivate an icon set and/or to use other icons. For more, see :ref:`custom-icons`.
+.. hint:: It is also possible to deactivate an icon set and/or to use other icons. For more, see :ref:`en/customization/yaml:Customizing icons`.
 
 More information on icons under:
 

--- a/en/elements/misc/link.rst
+++ b/en/elements/misc/link.rst
@@ -28,7 +28,7 @@ For some symbols you can choose between two different types of icons:
 
 The latter are based on a `IconSet <https://github.com/mapbender/icons>`_, which is delivered with Mapbender as a module. We recommend to use the symbols from this library.
 
-.. hint:: It is also possible to deactivate an icon set and/or to use other icons. For more, see :ref:`custom-icons`.
+.. hint:: It is also possible to deactivate an icon set and/or to use other icons. For more, see :ref:`en/customization/yaml:Customizing icons`.
 
 More information on icons under:
 

--- a/en/faq.rst
+++ b/en/faq.rst
@@ -13,7 +13,7 @@ Q: Why does Mapbender offer environments?
 
 A: For productive use, you'll use the `prod` environment. If you develop something (TWIG-files, CSS or JS-files) or want to debug, you should use the `dev` environment. This is because this mode provides more information and error messages. 
 
-For further information on the environments, please take a look at the chapter :ref:`environments`.
+For further information on the environments, please take a look at the chapter en/quickstart:Start Mapbender in a productive environment.
 
 
 Cache
@@ -25,7 +25,7 @@ A: The cache is a small storage area, where Mapbender accesses frequently needed
 
 It is no problem to delete these directories. When you run Mapbender again, new files will be stored again in the cache directory.
 
-For further information on the cache, please take a look at the chapter :ref:`app_cache`.
+For further information on the cache, please take a look at the chapter :ref:`en/installation/installation_configuration:Production and Development environment and Caching`.
 
 
 Services and their usage in applications
@@ -221,8 +221,8 @@ Q: I get a deprecation warning when I call bootstrap or composer update:
 A: This depends on the PHP version the system in running on and occurs on PHP versions < 7. Depending on the Mapbender release, we recommend different PHP versions that do not trigger the notices.
 
 
-Development
------------
+Developing
+----------
 
 Manual updates of modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/installation/installation_configuration.rst
+++ b/en/installation/installation_configuration.rst
@@ -124,8 +124,6 @@ The configuration files are located under ``application/config``.
 Find more information in: :ref:`yaml`.
 
 
-.. _app_cache:
-
 Production and Development environment and Caching
 --------------------------------------------------
 

--- a/en/installation/installation_ubuntu.rst
+++ b/en/installation/installation_ubuntu.rst
@@ -121,7 +121,6 @@ To use the optional LDAP-connection, following PHP-LDAP-extension is required:
 
 .. note:: To use LDAP, the `LDAP-Bundle <https://github.com/mapbender/ldapBundle>`_ must be integrated into Mapbender. Further setup instructions can be found in the bundle's README.md on GitHub.
 
-.. _postgres_install_config:
 
 Mapbender installation with PostgreSQL
 ++++++++++++++++++++++++++++++++++++++
@@ -190,4 +189,4 @@ Adapt these parameters (in parameters.yaml) accordingly:
                     database_driver:   pdo_mysql
                     database_port:     3306
 
-To initialize your database connection, see :ref:`postgres_install_config`.
+To initialize your database connection, see :ref:`en/installation/installation_ubuntu:Mapbender installation with PostgreSQL`.

--- a/en/installation/installation_windows.rst
+++ b/en/installation/installation_windows.rst
@@ -194,7 +194,7 @@ Troubleshooting is available via the following command (must be executed in the 
 
 .. hint:: Please note that config:check will use the php-cli version. The settings may be different from your webserver PHP settings. Please use php -r 'phpinfo();' to show your PHP webserver settings.
 
-Further information can be found at :ref:`mapbender_config_check`.
+Further information can be found at :ref:`en/customization/commands:bin/console mapbender:config:check`.
 
 Congratulations! Mapbender is now set up correctly and ready for further configuration.
 Find Information about the first steps with Mapbender in the :ref:`Mapbender Quickstart <quickstart>`.

--- a/en/installation/migration.rst
+++ b/en/installation/migration.rst
@@ -54,30 +54,20 @@ To update from 3.2.x to 3.3.x should be quite easy.
     If you update from a version < 3.2, you have to follow the steps described at the `Migration to Mapbender 3.2 <#Migration to Mapbender 3.2>`_ section below.
 
 
-New features
-============
-
-Styling
--------
-
-Styling is now possible via variables that can be passed to your application. 
-
-* `Mapbender <https://github.com/mapbender/mapbender/blob/master/src/Mapbender/CoreBundle/Resources/public/sass/libs/_variables.scss>`_
-* Create your own scss file, see this `Demo Bundle SCSS Example <https://github.com/mapbender/mapbender-workshop/blob/master/src/Workshop/DemoBundle/Resources/public/demo_variables_blue.scss>`_.
-* Modify your template - add function getSassVariablesAssets and refer to your scss file see, see this `Demo Bundle Template Example <https://github.com/mapbender/mapbender-workshop/blob/master/src/Workshop/DemoBundle/Template/DemoFullscreen.php#L23>`_.
 
 
-Sketch
-------
-
-* Sketch now supports to draw a circle with a defined radius. You draw the circle first and then edit the circle and define a radius.
-* Sketch now allows to define colors to be offered to draw. You can also activate a color picker
 
 
-FeatureInfo
------------
 
-* FeatureInfo Highlight now allows to style the fill and stroke and opacity
+
+
+
+
+
+
+
+
+
 
 
 Migration to Mapbender 3.2
@@ -139,8 +129,8 @@ You can update the configuration with the following SQL.
         Siegburg - this is the value not the key: Siegburg
 
 
-SimpleSearch
-============
+Migrating SimpleSearch
+======================
 
 SimpleSearch element was improved. You can now define the projection of the result that comes from the Solr Service. Mapbender will then transform the result to the projection of the map.
 
@@ -156,12 +146,12 @@ SimpleSearch Supports Nominatim, Photon from version 3.2.5 - see workshop demo a
                      query_ws_replace: +
 
 
-BaseSourceSwitcher
-==================
+Migrating BaseSourceSwitcher
+============================
 
-Please note that on start of an application, all WMS are activated where the root-Layer is activated.
+Please note that on start of an application, all WMS are activated where the root layer is activated.
 
-Before 3.2, it was possible to activate all Basesource and only the first WMS was visible on start.
+Before 3.2, it was possible to activate all BaseSources, where only the first WMS was visible on start.
 
 
 Template / CSS
@@ -173,8 +163,8 @@ CSS change. Plus, there will be a big redesign in backend and frontend in the up
 * Define your template as desktop-template
 
 
-Digitizer
-=========
+Migrating Digitizer
+===================
 
 Digitizer is available for Mapbender >= 3.2.2. The new Digitizer Version is 1.4. Some functionality is not updated to 1.4 already (e.g. cluster).
 
@@ -224,8 +214,8 @@ Make sure that your WMS provides a proper extent for all supported EPSG-codes (t
 Else it can happen that a layer is not requested for the given extent of your map.
 
 
-Sketch
-======
+Notice on the Sketch element
+============================
 
 Redlining was renamed to Sketch (>= 3.2.3).
 

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -63,9 +63,8 @@ This is how a Mapbender application can look like:
   .. image:: ../figures/mapbender_basic_application.png
      :width: 100%
 
-
-Installation
-============
+Install Mapbender
+=================
 
 This quickstart explains the basics of Mapbender and serves as a quick introduction after your first successful installation.
 For the installation of Mapbender have a look at :ref:`installation`.
@@ -79,8 +78,6 @@ For the installation of Mapbender have a look at :ref:`installation`.
 
 If you have any difficulties running Mapbender, please check whether your Apache web server and your PostgreSQL database are running without errors.
 
-
-.. _environments:
 
 Start Mapbender in a productive environment
 -------------------------------------------
@@ -237,8 +234,6 @@ The sources pages provides a user with the following functions:
      :width: 100%
 
 
-.. _load_sources:
-
 Load sources
 ------------
 
@@ -352,7 +347,7 @@ Currently, the element can be used to transfer user- and group information, e.g.
 * toggle allowed: allows opening in the layer tree
 * toggle on: open folder on start of the application
 * more information (...): opens a dialog with detailed layer information
-    * ID: ID of the layer. Can be useful :ref:`to control <layer_visibility>`URL parameters.
+    * ID: ID of the layer. Can be useful :ref:`to control <en/elements/basic/map:Make Layer visible>` URL parameters.
     * Name: layer name of the service information (for getMap-Requests)
     * Style: if a WMS provides more than one style you can choose a different style than the default style.
 


### PR DESCRIPTION
This PR adds the [shpinx.ext.autosectionlabel](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html) to the Mapbender docs (it also adds [sphinx.ext.duration](https://www.sphinx-doc.org/en/master/usage/extensions/duration.html) which is nice as a sphinx-build process duration log, but doesn't do much more).

The autosectionlabel is a good way to:

a) automatically define each text header in the docs as a potential crosslink target and
b) by this, also get rid of manual crosslink anchors.

This PR already implements b) and shortens documentation by this.

a) is done automatically when referring to a heading with the :ref: role, stating the doc path and file name, using a colon and then calling the section heading itself. Check the adjusted README.md for an example or see below.

In theory, with this extension the first anchor line of all .rst files becomes obsolete, but rearranging every single crosslink in the documentation is a job for another day...