### PR TITLE
Updates to database configuration + mailer config; clone description fix

### DIFF
--- a/de/architecture/directory_structure.rst
+++ b/de/architecture/directory_structure.rst
@@ -63,13 +63,13 @@ Die Übersetzungen werden in `YAML-Dateien <https://en.wikipedia.org/wiki/YAML>`
 public
 ******
 
-Dieses Verzeichnis muss vom Webserver veröffentlicht werden. Der ALIAS muss auf dieses Verzeichnis verweisen.
+Dieses Verzeichnis muss vom Webserver veröffentlicht werden. Der Alias muss auf dieses Verzeichnis verweisen.
 
 
 Es kontrolliert:
 
-* index.php - den FrontendController (PHP-Script, welches aufgerufen werden kann).
-
+* index.php: FrontendController (PHP-Script, welches aufgerufen werden kann).
+* index_dev.php: FrontendController als Zugangspunkt in die Entwicklungsumgebung.
 * dieses Verzeichnis beinhaltet die statischen Ressourcen wie css, js, favicon etc.
 
 

--- a/de/architecture/directory_structure.rst
+++ b/de/architecture/directory_structure.rst
@@ -69,7 +69,7 @@ Dieses Verzeichnis muss vom Webserver veröffentlicht werden. Der Alias muss auf
 Es kontrolliert:
 
 * index.php: FrontendController (PHP-Script, welches aufgerufen werden kann).
-* index_dev.php: FrontendController als Zugangspunkt in die Entwicklungsumgebung.
+* index_dev.php: FrontendController als Zugangspunkt in die Entwicklungsumgebung. Kann standardmäßig nur von lokalen IP-Adressen aufgerufen werden.
 * dieses Verzeichnis beinhaltet die statischen Ressourcen wie css, js, favicon etc.
 
 

--- a/de/customization/commands.rst
+++ b/de/customization/commands.rst
@@ -33,11 +33,20 @@ Anwendungs-Export, Import und Klonen
 bin/console mapbender:application:export 
 ****************************************
 
-Eine Anwendung kann als JSON- oder YAML-Datei exportiert werden. Dabei muss der Anwendungs-URL-Titel (slug) angebeben werden und eine Exportdatei definiert werden.
+Eine Anwendung kann als JSON- oder YAML-Datei exportiert werden. Dabei muss der Anwendungs-URL-Titel (slug) angebeben und eine Exportdatei definiert werden.
+
+Für .json-Dateien (Export über den Browser möglich):
 
 .. code-block:: yaml
 
    bin/console mapbender:application:export mapbender_user_db --format=json > export.json
+
+
+Für .yaml-Dateien (Export nur über die Kommandozeile möglich):
+
+.. code-block:: yaml
+
+   bin/console mapbender:application:export mapbender_user_db --format=yaml > export.yaml
 
 
 bin/console mapbender:application:import
@@ -56,8 +65,7 @@ Eine Anwendung kann aus einer JSON- oder YAML-Datei importiert werden. Mapbender
 bin/console mapbender:application:clone
 ***************************************
 
-Sie können auch eine bestehende Anwendung im Anwendungs-Backend klonen. Dadurch wird je eine neue Anwendung mit einem Suffix im Anwendungsnamen erzeugt. Bei yaml-Anwendungen wird ein *_db*-Suffix, bei Anwendungen aus der Datenbank ein *_imp*-Suffix angehängt. 
-Im untenstehenden Beispiel heißt die neue Anwendung `mapbender_user_yml_imp1`, weil sie aus der Datenbank heraus geklont wird.
+Sie können auch eine bestehende Anwendung im Anwendungs-Backend klonen. Dadurch wird eine neue Anwendung mit einem Suffix im Anwendungsnamen erzeugt. Bei yaml-Anwendungen wird ein *_db*-Suffix, bei Anwendungen aus der Datenbank ein *_imp*-Suffix angehängt. 
 
 .. code-block:: bash
 
@@ -82,7 +90,7 @@ Dabei sind die Angabe von Benutzername, Email und Passwort erforderlich. Der Ben
    
 **Aktualisierung eines Benutzers**
 
-Die folgendden Angaben zu einem Benutzer können aktualisiert werden:
+Die folgenden Angaben zu einem Benutzer können aktualisiert werden:
 
 * E-Mail
 * Passwort

--- a/de/customization/commands.rst
+++ b/de/customization/commands.rst
@@ -33,7 +33,7 @@ Anwendungs-Export, Import und Klonen
 bin/console mapbender:application:export 
 ****************************************
 
-Eine Anwendung kann als JSON- oder YAML-Datei exportiert werden. Dabei muss der Anwendungs-Url-Titel (slug) angebeben werden und eine Exportdatei definiert werden.
+Eine Anwendung kann als JSON- oder YAML-Datei exportiert werden. Dabei muss der Anwendungs-URL-Titel (slug) angebeben werden und eine Exportdatei definiert werden.
 
 .. code-block:: yaml
 
@@ -44,7 +44,6 @@ bin/console mapbender:application:import
 ****************************************
 
 Eine Anwendung kann aus einer JSON- oder YAML-Datei importiert werden. Mapbender wählt automatisch einen neuen Namen, wenn der Name bereits vorliegt. 
-You can import an application from a JSON-file. Mapbender will automatically choose a new name if the name already excists.  
 
 .. code-block:: yaml
    
@@ -57,8 +56,8 @@ You can import an application from a JSON-file. Mapbender will automatically cho
 bin/console mapbender:application:clone
 ***************************************
 
-Sie können auch eine bestehende Anwendung im Anwendungs-Backend klonen, also kopieren. Dadurch wird eine neue Anwendung mit einem *_imp* Suffix im Anwendungsnamen erzeugt. 
-Im untenstehenden Beispiel heißt die neue Anwendung `mapbender_user_yml_imp1`.
+Sie können auch eine bestehende Anwendung im Anwendungs-Backend klonen. Dadurch wird je eine neue Anwendung mit einem Suffix im Anwendungsnamen erzeugt. Bei yaml-Anwendungen wird ein *_db*-Suffix, bei Anwendungen aus der Datenbank ein *_imp*-Suffix angehängt. 
+Im untenstehenden Beispiel heißt die neue Anwendung `mapbender_user_yml_imp1`, weil sie aus der Datenbank heraus geklont wird.
 
 .. code-block:: bash
 

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -3,7 +3,7 @@
 YAML Konfiguration (Konfigurations- und Anwendungsdateien)
 ==========================================================
 
-Die folgenden Konfigurationsdateien sind zu finden unter application/config.
+Die folgenden Konfigurationsdateien liegen unter `application/config` und dessen Unterverzeichnissen:
 
 
 doctrine.yaml
@@ -51,18 +51,21 @@ Es folgt ein Beispiel mit zwei Datenbankverbindungen in der `doctrine.yaml`:
                     #server_version: '15'
                     logging:   "%kernel.debug%"
                     profiling: "%kernel.debug%"
-                # Datenbankverbindung search_db
-                search_db:
-                    url: '%env(resolve:SEARCH_DB_DATABASE_URL)%'
-                    charset:    UTF8
+                # Datenbankverbindung geodata_db
+                geodata_db:
+                    url: '%env(resolve:GEOBASIS_DATABASE_URL)%'
+                    persistent: true
+                    charset:  UTF8
+                    logging: '%kernel.debug%'
+                    profiling: '%kernel.debug%'
+                    # IMPORTANT: You MUST configure your server version,
+                    # either here or in the DATABASE_URL env var (see .env file)
                     #server_version: '15'
-                    logging:   "%kernel.debug%"
-                    profiling: "%kernel.debug%"
 
 
-.env
-----
-In dieser Datei werden zentrale Umgebungsvariablen zusammengeführt.
+.env (bzw. .env.local)
+----------------------
+In dieser Datei werden zentrale Umgebungsvariablen zusammengeführt:
 
 
 Datenbank
@@ -99,24 +102,27 @@ Mapbender verwendet Doctrine. Doctrine ist eine Sammlung von PHP-Bibliotheken un
 
 Mailer
 ******
-Die Mailerangaben werden in der `.env` Datei über eine Umgebungsvariable in der `mailer.yaml` eingetragen.
+Die Mailerangaben werden in der `.env.local` Datei über eine Umgebungsvariable in der `fom.yaml` eingetragen.
 
-Standard- und Beispielkonfiguration (auskommentiert) in der `.env`:
+Standard- und Beispielkonfiguration (auskommentiert) in der `.env.local`:
 
 .. code-block:: bash
 
     #MAILER_DSN=smtp://user:pass@smtp.example.com:25
     MAILER_DSN=null://null
 
-Die Umgebungsvariable wird danach im ``dsn`` Parameter in der `mailer.yaml` übertragen.
+Der Mailer-Einstellugnen selbst werden in `fom.yaml` konfiguriert.
 
 .. code-block:: yaml
 
-    framework:
-        mailer:
-            dsn: '%env(MAILER_DSN)%'
+    fom_user:
+        selfregister: false
+        reset_password: true
+        max_reset_time: 1
+        mail_from_address: info@mapbender.org
+        mail_from_name: Mapbender Team
            
-Ein Mailer wird für die Funktionen 'Self-Registration' und 'Passwort zurücksetzen' benötigt. Weitere Informationen im Kapitel :ref:`users_de`.
+.. hint:: Ein Mailer wird für die Funktionen 'Registrierung' und 'Passwort zurücksetzen' benötigt. Weitere Informationen im Kapitel :ref:`users_de`.
 
 
 parameters.yaml

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -22,7 +22,7 @@ Datenbank
 
 .. code-block:: yaml
 
-    doctrine:                                               # Bei Werten, die von dem %-Zeichen umschlossen werden,handelt es sich um Variablen
+    doctrine:
         dbal:
             default_connection: default                     # gibt die Datenbankverbindung an, die standardmäßig von Mapbender verwendet werden soll (``default_connection: default``).
             connections:
@@ -63,14 +63,15 @@ Es folgt ein Beispiel mit zwei Datenbankverbindungen in der `doctrine.yaml`:
                     #server_version: '15'
 
 
-.env (bzw. .env.local)
-----------------------
+.env bzw. .env.local
+--------------------
 In dieser Datei werden zentrale Umgebungsvariablen zusammengeführt:
 
 
 Datenbank
 *********
-Zur Konfiguration der Datenbankverbindung werden die Dateien `.env` und `doctrine.yaml` verwendet. In der `.env` wird die Umgebungsvariable für die Datenbankverbindung definiert. Diese wird in der `doctrine.yaml` aufgelöst. Alternativ können in der `doctrine.yaml` auch mehrere Datenbankverbindungen definiert werden. Zu jeder Datenbankverbindung wird ein Alias vergeben.
+Zur Konfiguration der Datenbankverbindung werden die Dateien `.env` und `doctrine.yaml` verwendet. In der `.env` wird die Umgebungsvariable für die Datenbankverbindung definiert. `.env` wird von `.env.local` überschrieben.
+Diese wird in der `doctrine.yaml` ausgelesen. In der `doctrine.yaml` können auch mehrere Datenbankverbindungen definiert werden. Zu jeder Datenbankverbindung wird ein Alias vergeben.
 
 Beispiel:
 Die Datenbankkonfiguration in der `.env` sieht standardmäßig folgendermaßen aus, sofern die mitinstallierte SQLite-Datenbank verwendet wird:
@@ -80,7 +81,7 @@ Die Datenbankkonfiguration in der `.env` sieht standardmäßig folgendermaßen a
     MAPBENDER_DATABASE_URL="sqlite:///%kernel.project_dir%/var/db/demo.sqlite"
 
 Beispiel:
-Die Datenbankkonfiguration in der `.env` sieht wie folgt aus, wenn eine Suchdatenbank via PostgreSQL referenziert wird:
+Die Datenbankkonfiguration in der `.env.local` sieht wie folgt aus, wenn eine Suchdatenbank via PostgreSQL referenziert wird:
 
 .. code-block:: bash
 
@@ -89,11 +90,11 @@ Die Datenbankkonfiguration in der `.env` sieht wie folgt aus, wenn eine Suchdate
 
 Verwendung mehrerer Datenbanken
 *******************************
-Mit Mapbender können Sie auch mehrere Datenbanken verwenden. Dies wird empfohlen, wenn Sie Ihre eigenen Daten von den Mapbender-Daten trennen möchten. Das kann nützlich sein, wenn Sie eigenen Code verwenden, der nicht zu einem Mapbender-Bundle gehört.
-Eine zweite Datenbank benötigen Sie ebenfalls für die Geodatensuche (über den :ref:`search_router_de`) und die Datenerfassung (:ref:`digitizer_de`). Die Geodaten sollten grundsätzlich in einer anderen Datenbank als der Mapbender Datenbank gesichert werden.
+Mit Mapbender können Sie auch mehrere Datenbanken verwenden. Dies wird bei der Einbindung von Geodaten empfohlen. Diese sollten getrennt von der Mapbender-Datenbank liegen.
+Eine zweite Datenbank benötigen Sie ebenfalls für die Geodatensuche (über den :ref:`search_router_de`) und die Datenerfassung (:ref:`digitizer_de`).
 Die Standard-Datenbankverbindung (``default_connection: default``) wird von Mapbender verwendet.
 
-Wenn Sie eine weitere Datenbank verwenden möchten, müssen Sie eine zweite Datenbankverbindung mit einem anderen Namen in der `.env`-Datei definieren.
+Wenn Sie eine weitere Datenbank verwenden möchten, müssen Sie eine zweite Datenbankverbindung mit einem anderen Namen in der `.env.local`-Datei definieren.
 In den Elementen :ref:`search_router_de` und :ref:`digitizer_de` kann nun auf die Datenbankverbindung (connection) mit dem Namen *search_db* verwiesen werden.
 
 Weitere Information über diese Konfigurationsmöglichkeit gibt es in der `Symfony Dokumentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
@@ -102,9 +103,7 @@ Mapbender verwendet Doctrine. Doctrine ist eine Sammlung von PHP-Bibliotheken un
 
 Mailer
 ******
-Die Mailerangaben werden in der `.env.local` Datei über eine Umgebungsvariable in der `fom.yaml` eingetragen.
-
-Standard- und Beispielkonfiguration (auskommentiert) in der `.env.local`:
+Die Angabe zum Mailer wird in der `.env.local` Datei über die Variable ``MAILER_DSN`` definiert.
 
 .. code-block:: bash
 
@@ -144,8 +143,6 @@ Es kann ein Disclaimer mittels Sitelinks hinzugefügt werden. Dafür muss Folgen
         text: Impressum & Kontakt									# Link Text
       - link: https://mapbender.org/datenschutz
         text: Datenschutz
-
-Die Sitelinks werden mittels "|" voneinander getrennt.
 
 
 .. _custom-icons_de:

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -13,7 +13,7 @@ Hier werden grundlegende Parameter von Mapbender bestimmt.
 
 Datenbank
 *********
-Zur Konfiguration der Datenbankverbindung werden die Dateien ``parameters.yaml`` und ``doctrine.yaml`` verwendet. In der ``parameters.yaml`` werden Variablen für die Datenbankverbindung definiert. Es können mehrere Datenbankverbindungen definiert werden. Die Variablen werden in der ``doctrine.yaml`` verarbeitet. Zu jeder Datenbankverbindung wird ein Alias vergeben.
+Zur Konfiguration der Datenbankverbindung werden die Dateien `.env` und `doctrine.yaml` verwendet. In der `.env` werden Variablen für die Datenbankverbindung definiert. Es können mehrere Datenbankverbindungen definiert werden. Die Variablen werden in der `doctrine.yaml` verarbeitet. Zu jeder Datenbankverbindung wird ein Alias vergeben.
 
 * **database_driver**: Der Datenbanktreiber. Mögliche Werte sind:
     * pdo_sqlite - SQLite PDO driver
@@ -25,7 +25,7 @@ Zur Konfiguration der Datenbankverbindung werden die Dateien ``parameters.yaml``
   Beachten Sie, dass Sie den entsprechenden PHP-Treiber installiert bzw. aktiviert haben.
 
 Beispiel:
-Die Datenbankkonfiguration in der ``parameters.yaml`` sieht folgendermaßen aus, wenn PostgreSQL verwendet wird:
+Die Datenbankkonfiguration in der `.env` sieht folgendermaßen aus, wenn PostgreSQL verwendet wird:
 
 .. code-block:: yaml
 
@@ -70,7 +70,7 @@ Wenn Sie eine weitere Datenbank verwenden möchten, müssen Sie eine zweite Date
         database2_password: postgres
 
 
-In den Elementen SearchRouter und Digitizer kann nun auf die Datenbankverbindung (connection) mit dem Namen **search_db** verwiesen werden.
+In den Elementen SearchRouter und Digitizer kann nun auf die Datenbankverbindung (connection) mit dem Namen *search_db* verwiesen werden.
 
 Weitere Information über diese Konfigurationsmöglichkeit gibt es in der `Symfony Dokumentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
 
@@ -82,7 +82,7 @@ Disclaimer
 
 .. image:: ../../figures/disclaimer.png
 
-Es kann ein Disclaimer mittels Sitelinks hinzugefügt werden. Dafür muss Folgendes in der ``parameters.yaml`` ergänzt werden:
+Es kann ein Disclaimer mittels Sitelinks hinzugefügt werden. Dafür muss Folgendes in der `parameters.yaml` ergänzt werden:
 
 .. code-block:: yaml
 
@@ -137,7 +137,7 @@ Mit diesen Konfigurationsoptionen können Sie die Icons in Mapbender an Ihre Anf
 
 Logo und Login-Bild
 *******************
-In der ``parameters.yaml`` kann auf das eigene Logo und auf ein alternatives Bild für den Login verwiesen werden. Diese Änderung wirkt sich global auf die gesamte Mapbender-Installation aus.
+In der `parameters.yaml` kann auf das eigene Logo und auf ein alternatives Bild für den Login verwiesen werden. Diese Änderung wirkt sich global auf die gesamte Mapbender-Installation aus.
 
 .. code-block:: yaml
 
@@ -150,34 +150,41 @@ Die Dateien müssen unter application/public verfügbar sein.
 
 Mailer
 ******
-Die Mailerangaben werden in der ``parameters.yaml`` über `mailer_dsn` eingetragen.
-Eine Konfiguration könnte wie folgt aussehen:
+Die Mailerangaben werden in der `.env.local` Datei über eine Umgebungsvariable in der `mailer.yaml` eingetragen.
+
+Standard- und Beispielkonfiguration (auskommentiert) in der `.env`:
+
+.. code-block:: bash
+
+    #MAILER_DSN=smtp://user:pass@smtp.example.com:25
+    MAILER_DSN=null://null
+
+Die Umgebungsvariable wird danach im ``dsn`` Parameter in der `mailer.yaml` übertragen.
 
 .. code-block:: yaml
 
-    mailer_dsn: smtp://user:pass@smtp.example.com:25
-
-
-Ein Mailer wird für die Funktionen 'Self-Registration' und 'Passwort zurücksetzen' benötigt.
-
-Weitere Informationen im Kapitel :ref:`users_de`.
+    framework:
+        mailer:
+            dsn: '%env(MAILER_DSN)%'
+           
+Ein Mailer wird für die Funktionen 'Self-Registration' und 'Passwort zurücksetzen' benötigt. Weitere Informationen im Kapitel :ref:`users_de`.
 
 
 Projektname
 ***********
-Der Projektname (Standard: Mapbender) kann in der Datei ``parameters.yaml`` angepasst werden. Diese Änderung wirkt sich global auf die gesamte Mapbender Installation aus.
+Der Projektname (Standard: Mapbender) kann in der Datei `parameters.yaml` angepasst werden. Diese Änderung wirkt sich global auf die gesamte Mapbender Installation aus.
 
 .. code-block:: yaml
 
     branding.project_name: Geoportal
 
 
-**Wichtiger Hinweis:** In der ``parameters.yaml`` dürfen **keine Tabulatoren für Einrückungen** verwendet werden.
+**Wichtiger Hinweis:** In der `parameters.yaml` dürfen **keine Tabulatoren für Einrückungen** verwendet werden.
 
 
 Proxy-Einstellungen
 *******************
-Wenn ein Proxy verwendet wird, muss dieser in der Datei ``parameters.yaml`` im Bereich OWSProxy Configuration angegeben werden.
+Wenn ein Proxy verwendet wird, muss dieser in der Datei `parameters.yaml` im Bereich OWSProxy Configuration angegeben werden.
 
 Eine Konfiguration könnte wie folgt aussehen:
 
@@ -240,7 +247,7 @@ Weitere Informationen unter :ref:`translation`.
 
 SSL Zertifikat
 **************
-Für Produktivumgebungen ist die Installation eines SSL-Zertifikats wichtig. Anschließend muss die Variable ``parameters.cookie_secure`` in Ihrer ``parameters.yaml`` auf ``true`` gesetzt werden. Dadurch wird sichergestellt, dass das Login-Cookie nur über sichere Verbindungen übertragen wird.
+Für Produktivumgebungen ist die Installation eines SSL-Zertifikats wichtig. Anschließend muss die Variable ``parameters.cookie_secure`` in Ihrer `parameters.yaml` auf ``true`` gesetzt werden. Dadurch wird sichergestellt, dass das Login-Cookie nur über sichere Verbindungen übertragen wird.
 
 
 .. _override_js_css_yaml_de:
@@ -261,7 +268,7 @@ Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :r
 doctrine.yaml
 -------------
 
-Diese Datei enthält grundlegende Architektur-Vorgaben von Mapbender. Gleichzeitig sind hier die Parameter für die ``parameters.yaml`` als Platzhalter definiert. Des Weiteren legt die Datei fest, welche Konfigurationen für den produktiven Modus und den Entwicklungsmodus verwendet werden sollen.
+Diese Datei enthält grundlegende Architektur-Vorgaben von Mapbender. Gleichzeitig sind hier die Parameter für die `parameters.yaml` als Platzhalter definiert. Des Weiteren legt die Datei fest, welche Konfigurationen für den produktiven Modus und den Entwicklungsmodus verwendet werden sollen.
 
 * **fom_user.selfregistration**: Um die Selbstregistrierung zu de/aktivieren, passen Sie den fom_user.selfregistration Parameter an.   Sie müssen unter self_registration_groups eine/mehrere Gruppen angeben, so dass selbstregistriere Anwender automatisch (bei der Registrierung) diesen Gruppen zugewiesen werden. Über die Gruppe bekommen Sie dann entsprechend Rechte zugewiesen.
 * **fom_user.reset_password**: Über diesen Parameter kann die Möglichkeit de/aktiviert werden, das Passwort neu zu setzen.
@@ -269,7 +276,7 @@ Diese Datei enthält grundlegende Architektur-Vorgaben von Mapbender. Gleichzeit
 
 Datenbank
 *********
-Wichtig: Jede Datenbank, die in der ``parameters.yaml`` definiert wird, muss auch als Platzhalter in der ``doctrine.yaml`` stehen:
+Wichtig: Jede Datenbank, die in der `parameters.yaml` definiert wird, muss auch als Platzhalter in der `doctrine.yaml` stehen:
 
 .. code-block:: yaml
 

--- a/de/customization/yaml.rst
+++ b/de/customization/yaml.rst
@@ -6,75 +6,122 @@ YAML Konfiguration (Konfigurations- und Anwendungsdateien)
 Die folgenden Konfigurationsdateien sind zu finden unter application/config.
 
 
-parameters.yaml
----------------
-Hier werden grundlegende Parameter von Mapbender bestimmt.
+doctrine.yaml
+-------------
+
+Diese Datei enthält grundlegende Architektur-Vorgaben von Mapbender. Gleichzeitig sind hier die Parameter für die `parameters.yaml` als Platzhalter definiert. Des Weiteren legt die Datei fest, welche Konfigurationen für den produktiven Modus und den Entwicklungsmodus verwendet werden sollen.
+
+* **fom_user.selfregistration**: Um die Selbstregistrierung zu de/aktivieren, passen Sie den fom_user.selfregistration Parameter an.   Sie müssen unter self_registration_groups eine/mehrere Gruppen angeben, so dass selbstregistriere Anwender automatisch (bei der Registrierung) diesen Gruppen zugewiesen werden. Über die Gruppe bekommen Sie dann entsprechend Rechte zugewiesen.
+* **fom_user.reset_password**: Über diesen Parameter kann die Möglichkeit de/aktiviert werden, das Passwort neu zu setzen.
+* **framework.session.cookie_httponly**: Stellen Sie für HTTP-only session cookies sicher, dass der Parameter framework.session.cookie_httponly auf true steht.
+
+Datenbank
+*********
+
+.. note:: Jede Datenbank, die in der `.env` definiert wird, muss als Platzhalter in der `doctrine.yaml` stehen:
+
+.. code-block:: yaml
+
+    doctrine:                                               # Bei Werten, die von dem %-Zeichen umschlossen werden,handelt es sich um Variablen
+        dbal:
+            default_connection: default                     # gibt die Datenbankverbindung an, die standardmäßig von Mapbender verwendet werden soll (``default_connection: default``).
+            connections:
+                default:
+                url: '%env(resolve:MAPBENDER_DATABASE_URL)%'# Platzhalter, der auf die definierte Umgebungsvariable in der parameters.yaml verweist. 
+                persistent: true                            # Parameter, ob die Verbindung zur Datenbank dauerhaft hergestellt werden soll.
+                charset:    UTF8                            # Die Kodierung, die die Datenbank verwendet.
+                logging:   "%kernel.debug%"                 # Die Option sorgt dafür, das alle SQLs nicht mehr geloggt werden (Standard: %kernel.debug%). `Mehr Informationen <http://www.loremipsum.at/blog/doctrine-2-sql-profiler-in-debugleiste>`_.
+                profiling: "%kernel.debug%"                 # Profiling von SQL Anfragen. Diese Option kann in der Produktion ausgeschaltet werden. (Standard: %kernel.debug%)
+                #server_version: '15'                       # Wichtig: Sie MÜSSEN die Serverversion konfigurieren, entweder hier oder in der DATABASE_URL Umgebungsvariable (siehe .env-Datei).
+
+**Verwendung mehrerer Datenbanken**
+
+Es folgt ein Beispiel mit zwei Datenbankverbindungen in der `doctrine.yaml`:
+
+.. code-block:: yaml
+
+    doctrine:
+        dbal:
+            default_connection: default
+            connections:
+                # Datenbankverbindung default
+                default:
+                    url: '%env(resolve:MAPBENDER_DATABASE_URL)%'
+                    charset:    UTF8
+                    #server_version: '15'
+                    logging:   "%kernel.debug%"
+                    profiling: "%kernel.debug%"
+                # Datenbankverbindung search_db
+                search_db:
+                    url: '%env(resolve:SEARCH_DB_DATABASE_URL)%'
+                    charset:    UTF8
+                    #server_version: '15'
+                    logging:   "%kernel.debug%"
+                    profiling: "%kernel.debug%"
+
+
+.env
+----
+In dieser Datei werden zentrale Umgebungsvariablen zusammengeführt.
 
 
 Datenbank
 *********
-Zur Konfiguration der Datenbankverbindung werden die Dateien `.env` und `doctrine.yaml` verwendet. In der `.env` werden Variablen für die Datenbankverbindung definiert. Es können mehrere Datenbankverbindungen definiert werden. Die Variablen werden in der `doctrine.yaml` verarbeitet. Zu jeder Datenbankverbindung wird ein Alias vergeben.
-
-* **database_driver**: Der Datenbanktreiber. Mögliche Werte sind:
-    * pdo_sqlite - SQLite PDO driver
-    * pdo_mysql - MySQL PDO driver
-    * pdo_pgsql - PostgreSQL PDO driver
-    * oci8 - Oracle OCI8 driver
-    * pdo_oci - Oracle PDO driver
-
-  Beachten Sie, dass Sie den entsprechenden PHP-Treiber installiert bzw. aktiviert haben.
+Zur Konfiguration der Datenbankverbindung werden die Dateien `.env` und `doctrine.yaml` verwendet. In der `.env` wird die Umgebungsvariable für die Datenbankverbindung definiert. Diese wird in der `doctrine.yaml` aufgelöst. Alternativ können in der `doctrine.yaml` auch mehrere Datenbankverbindungen definiert werden. Zu jeder Datenbankverbindung wird ein Alias vergeben.
 
 Beispiel:
-Die Datenbankkonfiguration in der `.env` sieht folgendermaßen aus, wenn PostgreSQL verwendet wird:
+Die Datenbankkonfiguration in der `.env` sieht standardmäßig folgendermaßen aus, sofern die mitinstallierte SQLite-Datenbank verwendet wird:
 
-.. code-block:: yaml
+.. code-block:: bash
 
-    database_driver:   pdo_pgsql
-    database_host:     localhost
-    database_port:     5432
-    database_name:     mapbender
-    database_path:     ~
-    database_user:     postgres
-    database_password: geheim
+    MAPBENDER_DATABASE_URL="sqlite:///%kernel.project_dir%/var/db/demo.sqlite"
+
+Beispiel:
+Die Datenbankkonfiguration in der `.env` sieht wie folgt aus, wenn eine Suchdatenbank via PostgreSQL referenziert wird:
+
+.. code-block:: bash
+
+    SEARCH_DB_DATABASE_URL="postgresql://dbuser:dbpassword@localhost:5432/dbname?serverVersion=14&charset=utf8"
 
 
 Verwendung mehrerer Datenbanken
 *******************************
 Mit Mapbender können Sie auch mehrere Datenbanken verwenden. Dies wird empfohlen, wenn Sie Ihre eigenen Daten von den Mapbender-Daten trennen möchten. Das kann nützlich sein, wenn Sie eigenen Code verwenden, der nicht zu einem Mapbender-Bundle gehört.
-
-Eine zweite Datenbank benötigen Sie ebenfalls für die *Geodatensuche* (über den SearchRouter) und die Datenerfassung (Digitizer). Die Geodaten sollten grundsätzlich in einer anderen Datenbank als der Mapbender Datenbank gesichert werden.
-
+Eine zweite Datenbank benötigen Sie ebenfalls für die Geodatensuche (über den :ref:`search_router_de`) und die Datenerfassung (:ref:`digitizer_de`). Die Geodaten sollten grundsätzlich in einer anderen Datenbank als der Mapbender Datenbank gesichert werden.
 Die Standard-Datenbankverbindung (``default_connection: default``) wird von Mapbender verwendet.
 
-Wenn Sie eine weitere Datenbank verwenden möchten, müssen Sie eine zweite Datenbankverbindung mit einem anderen Namen definieren.
+Wenn Sie eine weitere Datenbank verwenden möchten, müssen Sie eine zweite Datenbankverbindung mit einem anderen Namen in der `.env`-Datei definieren.
+In den Elementen :ref:`search_router_de` und :ref:`digitizer_de` kann nun auf die Datenbankverbindung (connection) mit dem Namen *search_db* verwiesen werden.
+
+Weitere Information über diese Konfigurationsmöglichkeit gibt es in der `Symfony Dokumentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
+Mapbender verwendet Doctrine. Doctrine ist eine Sammlung von PHP-Bibliotheken und bietet einen objektrelationalen Mapper und eine Datenbankabstraktionsschicht (`Doctrine Projektseite <https://www.doctrine-project.org/>`_).
+
+
+Mailer
+******
+Die Mailerangaben werden in der `.env` Datei über eine Umgebungsvariable in der `mailer.yaml` eingetragen.
+
+Standard- und Beispielkonfiguration (auskommentiert) in der `.env`:
+
+.. code-block:: bash
+
+    #MAILER_DSN=smtp://user:pass@smtp.example.com:25
+    MAILER_DSN=null://null
+
+Die Umgebungsvariable wird danach im ``dsn`` Parameter in der `mailer.yaml` übertragen.
 
 .. code-block:: yaml
 
-    parameters:
-        # Datenbankverbindung "default"
-        database_driver:   pdo_pgsql
-        database_host:     localhost
-        database_port:     5432
-        database_name:     mapbender
-        database_path:     ~
-        database_user:     postgres
-        database_password: postgres
-
-        # Datenbankverbindung "search_db"
-        database2_driver:   pdo_pgsql
-        database2_host:     localhost
-        database2_port:     5432
-        database2_name:     search_db
-        database2_path:     ~
-        database2_user:     postgres
-        database2_password: postgres
+    framework:
+        mailer:
+            dsn: '%env(MAILER_DSN)%'
+           
+Ein Mailer wird für die Funktionen 'Self-Registration' und 'Passwort zurücksetzen' benötigt. Weitere Informationen im Kapitel :ref:`users_de`.
 
 
-In den Elementen SearchRouter und Digitizer kann nun auf die Datenbankverbindung (connection) mit dem Namen *search_db* verwiesen werden.
-
-Weitere Information über diese Konfigurationsmöglichkeit gibt es in der `Symfony Dokumentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
-
-Mapbender verwendet Doctrine. Doctrine ist eine Sammlung von PHP-Bibliotheken und bietet einen objektrelationalen Mapper und eine Datenbankabstraktionsschicht (`Doctrine Projektseite <https://www.doctrine-project.org/>`_).
+parameters.yaml
+---------------
+Hier werden weitere grundlegende Parameter von Mapbender bestimmt.
 
 
 Disclaimer
@@ -146,28 +193,6 @@ In der `parameters.yaml` kann auf das eigene Logo und auf ein alternatives Bild 
 
 
 Die Dateien müssen unter application/public verfügbar sein.
-
-
-Mailer
-******
-Die Mailerangaben werden in der `.env.local` Datei über eine Umgebungsvariable in der `mailer.yaml` eingetragen.
-
-Standard- und Beispielkonfiguration (auskommentiert) in der `.env`:
-
-.. code-block:: bash
-
-    #MAILER_DSN=smtp://user:pass@smtp.example.com:25
-    MAILER_DSN=null://null
-
-Die Umgebungsvariable wird danach im ``dsn`` Parameter in der `mailer.yaml` übertragen.
-
-.. code-block:: yaml
-
-    framework:
-        mailer:
-            dsn: '%env(MAILER_DSN)%'
-           
-Ein Mailer wird für die Funktionen 'Self-Registration' und 'Passwort zurücksetzen' benötigt. Weitere Informationen im Kapitel :ref:`users_de`.
 
 
 Projektname
@@ -263,79 +288,6 @@ Um genannte Ressourcen manuell zu überschreiben, können Sie als Alternative :r
 
 
 .. note:: Beachten Sie, dass das `@`-Zeichen im Ersetzungsschlüssel durch ein weiteres `@@`-Zeichen maskiert werden muss.
-
-
-doctrine.yaml
--------------
-
-Diese Datei enthält grundlegende Architektur-Vorgaben von Mapbender. Gleichzeitig sind hier die Parameter für die `parameters.yaml` als Platzhalter definiert. Des Weiteren legt die Datei fest, welche Konfigurationen für den produktiven Modus und den Entwicklungsmodus verwendet werden sollen.
-
-* **fom_user.selfregistration**: Um die Selbstregistrierung zu de/aktivieren, passen Sie den fom_user.selfregistration Parameter an.   Sie müssen unter self_registration_groups eine/mehrere Gruppen angeben, so dass selbstregistriere Anwender automatisch (bei der Registrierung) diesen Gruppen zugewiesen werden. Über die Gruppe bekommen Sie dann entsprechend Rechte zugewiesen.
-* **fom_user.reset_password**: Über diesen Parameter kann die Möglichkeit de/aktiviert werden, das Passwort neu zu setzen.
-* **framework.session.cookie_httponly**: Stellen Sie für HTTP-only session cookies sicher, dass der Parameter framework.session.cookie_httponly auf true steht.
-
-Datenbank
-*********
-Wichtig: Jede Datenbank, die in der `parameters.yaml` definiert wird, muss auch als Platzhalter in der `doctrine.yaml` stehen:
-
-.. code-block:: yaml
-
-    doctrine:                                               # Bei Werten, die von dem %-Zeichen umschlossen werden,handelt es sich um Variablen
-        dbal:
-            default_connection: default                     # gibt die Datenbankverbindung an, die standardmäßig von Mapbender verwendet werden soll (``default_connection: default``).
-            connections:
-                default:
-                driver:    "%database_driver%"              # Mehr Information unterhalb des Codes
-                host:      "%database_host%"                # Der Host, auf dem die Datenbank läuft. Entweder der Name (z.B. localhost) oder die IP-Adresse (z.B. 127.0.0.1).
-                port:      "%database_port%"                # Der Port, auf dem die Datenbank lauscht (z.B. 5432 für PostgreSQL).
-                dbname:    "%database_name%"                # Der Name der Datenbank (z.B. mapbender). Erstellen Sie die Datenbank mit dem Befehl ``doctrine:database:create`` bzw. ``doctrine:schema:create``.
-                path:      "%database_path%"                # Der %database_path% ist der Pfad zur Datei der SQLite-Datenbank. Wenn Sie keine SQLite-Datenbank verwenden, schreiben Sie als Wert entweder eine Tilde (~) oder ``null``.
-                user:      "%database_user%"                # Benutzername für die Verbindung zur Datenbank.
-                password:  "%database_password%"            # Das Passwort des Datenbankbenutzers.
-                persistent: true                            # Parameter, ob die Verbindung zur Datenbank dauerhaft hergestellt werden soll.
-                charset:    UTF8                            # Die Kodierung, die die Datenbank verwendet.
-                logging:   "%kernel.debug%"                 # Die Option sorgt dafür, das alle SQLs nicht mehr geloggt werden (Standard: %kernel.debug%). `Mehr Informationen <http://www.loremipsum.at/blog/doctrine-2-sql-profiler-in-debugleiste>`_.
-                profiling: "%kernel.debug%"                 # Profiling von SQL Anfragen. Diese Option kann in der Produktion ausgeschaltet werden. (Standard: %kernel.debug%)
-                #server_version: '15'                       # Wichtig: Sie MÜSSEN die Serverversion konfigurieren, entweder hier oder in der DATABASE_URL Umgebungsvariable (siehe .env-Datei).
-
-**Verwendung mehrerer Datenbanken**
-
-Es folgt ein Beispiel mit zwei Datenbankverbindungen in der **doctrine.yaml**:
-
-.. code-block:: yaml
-
-    doctrine:
-        dbal:
-            default_connection: default
-            connections:
-                # Datenbankverbindung default
-                default:
-                    driver:    "%database_driver%"
-                    host:      "%database_host%"
-                    port:      "%database_port%"
-                    dbname:    "%database_name%"
-                    path:      "%database_path%"
-                    user:      "%database_user%"
-                    password:  "%database_password%"
-                    charset:    UTF8
-                    #server_version: '15'
-                    logging:   "%kernel.debug%"
-                    profiling: "%kernel.debug%"
-                # Datenbankverbindung search_db
-                search_db:
-                    driver:    "%database2_driver%"
-                    host:      "%database2_host%"
-                    port:      "%database2_port%"
-                    dbname:    "%database2_name%"
-                    path:      "%database2_path%"
-                    user:      "%database2_user%"
-                    password:  "%database2_password%"
-                    charset:    UTF8
-                    #server_version: '15'
-                    logging:   "%kernel.debug%"
-                    profiling: "%kernel.debug%"
-
-Weitere Informationen weiter oben unter parameters.yaml.
 
 
 YAML Anwendungsdateien

--- a/de/installation/installation_configuration.rst
+++ b/de/installation/installation_configuration.rst
@@ -137,7 +137,7 @@ In der Produktionsumgebung wird das Caching aktiviert, zusätzlich werden nur al
 Eine Umgebung kann über die Variable ``APP_ENV`` explizit festgelegt werden. Stellen Sie sicher, dass Sie dies auf `prod` ändern, wenn Sie Ihre Anwendung für die Öffentlichkeit bereitstellen. Der Wert kann auf verschiedene Arten geändert werden:
 
 * durch Bearbeiten der ``APP_ENV``-Variable in der `.env`-Datei,
-* durch Hinzufügen einer `.env.local`-Datei und Überschreiben des Werts dort,
+* durch Überschreiben des Werts in einer `.env.local`-Datei,
 * durch Festlegen einer Umgebungsvariable in Ihrer Apache2-vHost-Konfiguration: ``SetEnv APP_ENV prod``,
 * durch explizites Festlegen beim Starten des lokalen Webservers:
 

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -92,7 +92,7 @@ In der Produktionsumgebung wird das Caching aktiviert, zusätzlich werden nur al
 Eine Umgebung kann über die Variable ``APP_ENV`` explizit festgelegt werden. Stellen Sie sicher, dass Sie dies auf `prod` ändern, wenn Sie Ihre Anwendung für die Öffentlichkeit bereitstellen. Der Wert kann auf verschiedene Arten geändert werden:
 
 * durch Bearbeiten der ``APP_ENV``-Variable in der `.env`-Datei,
-* durch Hinzufügen einer `.env.local`-Datei und Überschreiben des Werts dort,
+* durch Überschreiben des Werts in einer `.env.local`-Datei,
 * durch Festlegen einer Umgebungsvariable in Ihrer Apache2-vHost-Konfiguration: ``SetEnv APP_ENV prod``,
 * durch explizites Festlegen beim Starten des lokalen Webservers:
 

--- a/de/quickstart.rst
+++ b/de/quickstart.rst
@@ -138,7 +138,7 @@ In der Anwendungsübersicht finden Sie eine Liste mit allen verfügbaren Anwendu
 
 Es gibt drei verschiedene Möglichkeiten, durch die neue Anwendungen erstellt werden können:
 
-Einerseits besteht die Option, diese aus bereits vorhandenen Anwendungen zu erstellen. Dies erfolgt über einen Klick auf den |mapbender-button-copy| Button in der Anwendungsübersicht. Die Applikation erhält dabei den gleichen Titel und URL-Titel zuzüglich dem Zusatz *"_imp"*. Alle zuvor definierten Elemente und Konfigurationen werden ebenfalls übernommen. Eine weitere Möglichkeit ist der Import einer Anwendung. Zusätzliche Informationen hierzu finden sich unter :ref:`yaml_de`.
+Einerseits besteht die Option, diese aus bereits vorhandenen Anwendungen zu erstellen. Dies erfolgt über einen Klick auf den |mapbender-button-copy| Button in der Anwendungsübersicht. Die Applikation erhält dabei den gleichen Titel und URL-Titel zuzüglich dem Zusatz *"_db"* (bei yaml-Anwendungen) oder *"_imp"* (bei Anwendungen, die aus der :ref:`Datenbank <postgres_install_config_de>` heraus kopiert werden). Alle zuvor definierten Elemente und Konfigurationen werden ebenfalls übernommen. Eine weitere Möglichkeit ist der Import einer Anwendung. Zusätzliche Informationen hierzu finden sich unter :ref:`yaml_de`.
 
 Es können außerdem komplett neue Anwendungen über das :ref:`backend_de` definiert werden. Die einzelnen Arbeitsschritte hierfür werden im Folgenden näher erläutert:
 

--- a/en/architecture/directory_structure.rst
+++ b/en/architecture/directory_structure.rst
@@ -66,7 +66,7 @@ This directory has to be published by the webserver. The ALIAS has to refer to t
 It controls: 
 
 * index.php - the FrontendController (PHP script which can be called).
-* index_dev.php - FrontendController for easy access to the development environment.
+* index_dev.php - FrontendController for easy access to the development environment. By default, it can only be accessed from local IP addresses.
 * this directory contains the static resoures like css, js, favicon etc.
 
 

--- a/en/architecture/directory_structure.rst
+++ b/en/architecture/directory_structure.rst
@@ -65,7 +65,8 @@ This directory has to be published by the webserver. The ALIAS has to refer to t
 
 It controls: 
 
-* index.php - the FrontendController (PHP-Script, which can be called).
+* index.php - the FrontendController (PHP script which can be called).
+* index_dev.php - FrontendController for easy access to the development environment.
 * this directory contains the static resoures like css, js, favicon etc.
 
 

--- a/en/customization/commands.rst
+++ b/en/customization/commands.rst
@@ -56,8 +56,8 @@ You can import an application from a JSON or YAML-file. Mapbender will automatic
 bin/console mapbender:application:clone
 ***************************************
 
-You can clone an existing application in the Application backend. This will create a new application with a *_imp* suffix as application name.
-In the example below, the name of the new application becomes `mapbender_user_yml_imp1`.
+You can also clone an existing application in the application backend. This will generate a new application with a suffix added to the application name. For yaml applications, a *_db* suffix is appended, while for applications from the database, a *_imp* suffix is added.
+In the example below, the new application is named `mapbender_user_yml_imp1` because it is cloned from the database.
 
 .. code-block:: bash
 

--- a/en/customization/commands.rst
+++ b/en/customization/commands.rst
@@ -35,9 +35,18 @@ bin/console mapbender:application:export
 
 You can export an application as JSON- or YAML-file. In the command you have to add the Url title (slug) of the application and define the export file.
 
+For .json files (also available via browser):
+
 .. code-block:: yaml
 
    bin/console mapbender:application:export mapbender_user_db --format=json > export.json
+
+
+For .yaml files (only via command line):
+
+.. code-block:: yaml
+
+   bin/console mapbender:application:export mapbender_user_db --format=yaml > export.yaml
 
 
 bin/console mapbender:application:import
@@ -56,8 +65,7 @@ You can import an application from a JSON or YAML-file. Mapbender will automatic
 bin/console mapbender:application:clone
 ***************************************
 
-You can also clone an existing application in the application backend. This will generate a new application with a suffix added to the application name. For yaml applications, a *_db* suffix is appended, while for applications from the database, a *_imp* suffix is added.
-In the example below, the new application is named `mapbender_user_yml_imp1` because it is cloned from the database.
+In the application backend, you can also clone an existing application. This will generate a new application with a suffix added to the application name. For yaml applications, a *_db* suffix is appended, while for applications from the database, a *_imp* suffix is added.
 
 .. code-block:: bash
 

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -20,7 +20,7 @@ Database
 
 .. code-block:: yaml
 
-    doctrine:                                               # Values, surrounded by %-marks, are variables
+    doctrine:
         dbal:
             default_connection: default                     # Database connection, used as standard in Mapbender (``default_connection: default``).
             connections:
@@ -69,10 +69,11 @@ This file handles necessary environmental variables:
 
 Database
 ********
-The files `.env` and `doctrine.yaml` are needed to configure databases in Mapbender. In `.env`, (multiple) variables for database connection(s) can be defined. These variables are being processed in `doctrine.yaml`. An alias is assigned to each database connection.
+The files `.env` and `doctrine.yaml` are used to configure database connections in Mapbender. In `.env`, (multiple) variables for database connection(s) can be defined. The `.env` is overwritten by `.env.local`.
+This is read by `doctrine.yaml`. Several database connections can also be defined in `doctrine.yaml`. An alias is assigned to each database connection.
 
 Example:
-Database configuration in `.env` with the default database variable, if the pre-installed SQLite database is used:
+Database configuration in `.env.local` with the default database variable, if the pre-installed SQLite database is used:
 
 .. code-block:: bash
 
@@ -87,11 +88,11 @@ When using PostgreSQL (e.g. for the use with :ref:`search_router`), use the foll
 
 Use of several databases
 ************************
-Mapbender can handle several databases. This is recommended if you want to keep your data seperated from Mapbender data. Or if you want to use code that doesn't belong to a Mapbender bundle.
+Mapbender also allows you to use several databases. This is recommended when integrating geodata. These should be stored separately from the Mapbender database.
 You need a second database for geo data search (with SearchRouter) and data collection (Digitizer).
 The default database connection (``default_connection: default``) is used by Mapbender.
 
-If you want to use another database, you just have to define a database connection with a different name in your `.env` file.
+If you want to use another database, you just have to define a database connection with a different name in your `.env.local` file.
 Now, you can refer to the database *search_db* in the elements SearchRouter and Digitizer.
 
 To learn more about this structure, visit the `Symfony documentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
@@ -100,9 +101,7 @@ Mapbender uses Doctrine. Doctrine is a collection of PHP libaries (`Doctrine pro
 
 Mailer
 *******
-Mailer information are inserted in the `fom.yaml` file via environment variables in your `.env.local` (e.g. smtp or sendmail).
-
-Default and configuration example (commented out) in `.env.local`:
+The mailer information is defined in the `.env.local` file via the ``MAILER_DSN`` variable.
 
 .. code-block:: bash
 
@@ -143,8 +142,6 @@ A disclaimer can be added through the use of site links.
         text: Imprint & Contact									    # Link text
       - link: https://mapbender.org/en/privacy-policy/
         text: Privacy Policy
-
-Site links will be seperated by "|".
 
 
 .. _custom-icons:

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -3,7 +3,7 @@
 YAML Configuration (Configuration and Application files)
 ========================================================
 
-The following Configuration files are under application/config.
+The following configuration files are under `application/config` and its subfolders.
 
 
 doctrine.yaml
@@ -50,18 +50,21 @@ Example with two database connections in `doctrine.yaml`:
                     #server_version: '15' 
                     logging:   "%kernel.debug%"
                     profiling: "%kernel.debug%"
-                # database connection search_db
-                search_db:
-                    url: '%env(resolve:SEARCH_DB_DATABASE_URL)%'
-                    charset:    UTF8
-                    #server_version: '15' 
-                    logging:   "%kernel.debug%"
-                    profiling: "%kernel.debug%".env
+                # database connection geodata_db
+                geodata_db:
+                    url: '%env(resolve:GEOBASIS_DATABASE_URL)%'
+                    persistent: true
+                    charset:  UTF8
+                    logging: '%kernel.debug%'
+                    profiling: '%kernel.debug%'
+                    # IMPORTANT: You MUST configure your server version,
+                    # either here or in the DATABASE_URL env var (see .env file)
+                    #server_version: '15'
 
 
-.env
-----
-This file handles necessary environmental variables.
+.env or .env.local file
+-----------------------
+This file handles necessary environmental variables:
 
 
 Database
@@ -97,25 +100,28 @@ Mapbender uses Doctrine. Doctrine is a collection of PHP libaries (`Doctrine pro
 
 Mailer
 *******
-Mailer information are inserted in the `mailer.yaml` file via environment variables in your `.env` (e.g. smtp or sendmail).
+Mailer information are inserted in the `fom.yaml` file via environment variables in your `.env.local` (e.g. smtp or sendmail).
 
-Default and configuration example (commented out) in `.env`:
+Default and configuration example (commented out) in `.env.local`:
 
 .. code-block:: bash
 
     #MAILER_DSN=smtp://user:pass@smtp.example.com:25
     MAILER_DSN=null://null
 
-The environment variable will be inserted into the ``dsn`` parameter in the `mailer.yaml` file.
+
+The configuration will be called via the `fom.yaml` file:
 
 .. code-block:: yaml
 
-    framework:
-        mailer:
-            dsn: '%env(MAILER_DSN)%'
+    fom_user:
+        selfregister: false
+        reset_password: true
+        max_reset_time: 1
+        mail_from_address: info@mapbender.org
+        mail_from_name: Mapbender Team
 
-
-The functions 'Self-Registration' and 'reset password' need a mailer. More information in chapter :ref:`users`.
+.. hint:: The functions 'Self-Registration' and 'Reset password' need a mailer. More information in chapter :ref:`users`.
 
 
 parameters.yaml

--- a/en/customization/yaml.rst
+++ b/en/customization/yaml.rst
@@ -13,7 +13,7 @@ The following fundamental Mapbender parameters are specified here.
 
 Database
 ********
-The files ``parameters.yaml`` and ``doctrine.yaml`` are needed to configure databases in Mapbender. In ``parameters.yaml``, (multiple) variables for database connection(s) can be defined. These variables are being processed in ``doctrine.yaml``. An alias is assigned to each database connection.
+The files `.env` and `doctrine.yaml` are needed to configure databases in Mapbender. In `.env`, (multiple) variables for database connection(s) can be defined. These variables are being processed in `doctrine.yaml`. An alias is assigned to each database connection.
 
 * **database_driver**: Database driver. Possible values are:
     * pdo_sqlite - SQLite PDO driver
@@ -25,7 +25,7 @@ The files ``parameters.yaml`` and ``doctrine.yaml`` are needed to configure data
   Please note: Necessary PHP drivers need to be installed and activated.
 
 Example:
-Database configuration in ``parameters.yaml``, when PostgreSQL is used:
+Database configuration in `.env`, when PostgreSQL is used:
 
 .. code-block:: yaml
 
@@ -70,7 +70,7 @@ If you want to use another database, you have to define a database connection wi
         database2_password: postgres
 
 
-Now, you can refer to the database **search_db** in the elements SearchRouter and Digitizer.
+Now, you can refer to the database *search_db* in the elements SearchRouter and Digitizer.
 
 To learn more about this structure, visit the `Symfony documentation <https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration>`_.
 
@@ -192,34 +192,42 @@ In parameters.yaml, you can refer to your own logo and to an alternative image f
 
 Mailer
 *******
-Mailer information are inserted in ``parameters.yaml`` via the `mailer_dsn` parameter (e.g. smtp or sendmail).
+Mailer information are inserted in the `mailer.yaml` file via environment variables in your `.env.local` (e.g. smtp or sendmail).
 
-Configuration example:
+Default and configuration example (commented out) in `.env`:
+
+.. code-block:: bash
+
+    #MAILER_DSN=smtp://user:pass@smtp.example.com:25
+    MAILER_DSN=null://null
+
+The environment variable will be inserted into the ``dsn`` parameter in the `mailer.yaml` file.
 
 .. code-block:: yaml
 
-    mailer_dsn: smtp://user:pass@smtp.example.com:25
+    framework:
+        mailer:
+            dsn: '%env(MAILER_DSN)%'
 
-The functions 'Self-Registration' and 'reset password' need a mailer.
 
-More information in chapter :ref:`users`.
+The functions 'Self-Registration' and 'reset password' need a mailer. More information in chapter :ref:`users`.
 
 
 Project name
 ************
-The name of the project (default: Mapbender) can be changed in ``parameters.yaml``. The change has a global impact on the whole Mapbender installation.
+The name of the project (default: Mapbender) can be changed in `parameters.yaml`. The change has a global impact on the whole Mapbender installation.
 
 .. code-block:: yaml
 
     branding.project_name: Geoportal
 
 
-**Important note:** In ``parameters.yaml`` **tabulators may not be used for indentation** instead you need to use space.
+**Important note:** In `parameters.yaml` **tabulators may not be used for indentation** instead you need to use space.
 
 
 Proxy settings
 **************
-If you use a proxy, you need to change ``parameters.yaml``.
+If you use a proxy, you need to change `parameters.yaml`.
 
 .. hint:: OWSProxy3 is a transparent Buzz-based proxy that uses cURL for connection to web resources via/without a proxy server.
 
@@ -242,7 +250,7 @@ Configuration example:
 
 SSL certificate
 ***************
-For productive environments, it is important to install a SSL certificate. After that, set the ``parameters.cookie_secure`` variable in your ``parameters.yaml`` to ``true``. This ensures that the Login cookie is only transmitted over secure connections.
+For productive environments, it is important to install a SSL certificate. After that, set the ``parameters.cookie_secure`` variable in your `parameters.yaml` to ``true``. This ensures that the Login cookie is only transmitted over secure connections.
 
 
 .. _override_js_css_yaml:
@@ -270,7 +278,7 @@ doctrine.yaml
 
 Database
 ********
-Important: Every database defined in parameters.yaml needs to have a placeholder in ``doctrine.yaml`` as well:
+Important: Every database defined in parameters.yaml needs to have a placeholder in `doctrine.yaml` as well:
 
 .. code-block:: yaml
 
@@ -295,7 +303,7 @@ Important: Every database defined in parameters.yaml needs to have a placeholder
 
 Use of several databases
 ************************
-Example with two database connections in ``doctrine.yaml``:
+Example with two database connections in `doctrine.yaml`:
 
 .. code-block:: yaml
 
@@ -330,7 +338,7 @@ Example with two database connections in ``doctrine.yaml``:
                     logging:   "%kernel.debug%"
                     profiling: "%kernel.debug%"
 
-More information under ``parameters.yaml``.
+More information under `parameters.yaml`.
 
 
 YAML Application files

--- a/en/installation/installation_configuration.rst
+++ b/en/installation/installation_configuration.rst
@@ -137,7 +137,7 @@ The productive environment enables caching and only shows generic error messages
 The environment can be set via the ``APP_ENV`` variable. Make sure to change this to `prod` when deploying your application for the public. The value can be changed in several ways:
 
 * by editing the ``APP_ENV`` variable in the `.env` file,
-* by overriding the value in a `.env.local` file,
+* by overriding the value in an `.env.local` file,
 * by setting an environment variable in your Apache2 vHost configuration: ``SetEnv APP_ENV prod``,
 * by explicitly setting it when starting the local webserver:
 

--- a/en/installation/installation_configuration.rst
+++ b/en/installation/installation_configuration.rst
@@ -137,7 +137,7 @@ The productive environment enables caching and only shows generic error messages
 The environment can be set via the ``APP_ENV`` variable. Make sure to change this to `prod` when deploying your application for the public. The value can be changed in several ways:
 
 * by editing the ``APP_ENV`` variable in the `.env` file,
-* by adding a `.env.local` file and overriding the value there,
+* by overriding the value in a `.env.local` file,
 * by setting an environment variable in your Apache2 vHost configuration: ``SetEnv APP_ENV prod``,
 * by explicitly setting it when starting the local webserver:
 

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -93,7 +93,7 @@ The productive environment enables caching and only shows generic error messages
 The environment can be set via the ``APP_ENV`` variable. Make sure to change this to `prod` when deploying your application for the public. The value can be changed in several ways:
 
 * by editing the ``APP_ENV`` variable in the `.env` file,
-* by overriding the value in a `.env.local` file,
+* by overriding the value in an `.env.local` file,
 * by setting an environment variable in your Apache2 vHost configuration: ``SetEnv APP_ENV prod``,
 * by explicitly setting it when starting the local webserver:
 

--- a/en/quickstart.rst
+++ b/en/quickstart.rst
@@ -93,7 +93,7 @@ The productive environment enables caching and only shows generic error messages
 The environment can be set via the ``APP_ENV`` variable. Make sure to change this to `prod` when deploying your application for the public. The value can be changed in several ways:
 
 * by editing the ``APP_ENV`` variable in the `.env` file,
-* by adding a `.env.local` file and overriding the value there,
+* by overriding the value in a `.env.local` file,
 * by setting an environment variable in your Apache2 vHost configuration: ``SetEnv APP_ENV prod``,
 * by explicitly setting it when starting the local webserver:
 


### PR DESCRIPTION
- This PR fixes the wrong description of app cloning behaviour (_imp from yaml, _db from database).
- Moreover, it implements the database configuration changes to the documentation which were added via [mapbender-starter PR #117](https://github.com/mapbender/mapbender-starter/pull/117)
- It also updates the mailer config as requested in #433 