### PR TITLE
Changes made to the Legend Doku Text

### DIFF
--- a/de/elements/basic/legend.rst
+++ b/de/elements/basic/legend.rst
@@ -58,23 +58,16 @@ Die Legende kann auch als Button in der Werkzeugleiste eingebunden werden. Hierf
 
 Für das Konfigurationsbeispiel wurden folgende Einstellungen gewählt:
 
-.. image:: ../../../figures/de/legend_example_toolbar_dialog.png
-     :scale: 80
+.. image:: ../../../figures/de/legend_example_sidepane_dialog.png
+     :scale: 70
 
-Für das Konfigurationsbeispiel wurde das Häkchen bei *Automatisches Öffnen* entfernt, sodass sich die Legende nur bei aktivem Klicken auf einen Button öffnet.
 Sobald dieses Element im Kartenbereich eingebunden wurde, muss ein Button in der oberen Werkzeugleiste eingefügt werden. Die Konfiguration von Buttons wird in der Mapbender-Dokumentation unter :ref:`button_de` beschrieben.
-
-Die Konfiguration eines Buttons für die Legende kann wie folgt aussehen:
-
-.. image:: ../../../figures/de/legend_example_button.png
-     :scale: 80
-
 Mit diesen Einstellungen sieht das Ergebnis in der Anwendung wie folgt aus:
 
-.. image:: ../../../figures/de/legend_example_toolbar.png
+.. image:: ../../../figures/de/legend.png
      :scale: 80
 
-In der Oberen Werkzeugleiste (Toolbar) ist der Button für das Legenden-Element zu sehen. Sobald auf den Button geklickt wird, öffnet sich ein Dialog mit der Legende.
+In der Oberen Werkzeugleiste (Toolbar) ist der Button für das Legenden-Element zu sehen. Sobald auf den Button geklickt wird, öffnet sich ein Dialog mit der Legende(wird in unserem Beispiel automatisch geöffnet).
 
 Inwiefern sich die Aktivierung bzw. Deaktivierung einzelner Haken auf die Legende auswirkt, ist hier zu sehen:
 

--- a/de/elements/basic/legend.rst
+++ b/de/elements/basic/legend.rst
@@ -67,7 +67,7 @@ Mit diesen Einstellungen sieht das Ergebnis in der Anwendung wie folgt aus:
 .. image:: ../../../figures/de/legend.png
      :scale: 80
 
-In der Oberen Werkzeugleiste (Toolbar) ist der Button für das Legenden-Element zu sehen. Sobald auf den Button geklickt wird, öffnet sich ein Dialog mit der Legende(wird in unserem Beispiel automatisch geöffnet).
+In der Oberen Werkzeugleiste (Toolbar) ist der Button für das Legenden-Element zu sehen. Sobald auf den Button geklickt wird, öffnet sich ein Dialog mit der Legende. Durch die Einstellung "Automatisch öffnen" wird der Dialog beim Start der Anwendung direkt angezeigt.
 
 Inwiefern sich die Aktivierung bzw. Deaktivierung einzelner Haken auf die Legende auswirkt, ist hier zu sehen:
 

--- a/en/elements/basic/legend.rst
+++ b/en/elements/basic/legend.rst
@@ -59,28 +59,21 @@ The legend element can be integrated with a button in the toolbar. First step: O
 
 In this example, the following settings are chosen:
 
-.. image:: ../../../figures/legend_example_toolbar_dialog.png
-     :scale: 75
+.. image:: ../../../figures/legend_example_sidepane_dialog.png
+     :scale: 70
 
-In our example, the checkbox *Open automatically* is dismissed. Therefore, the legend opens only with a click on a button.
-This :ref:`button` has to be implemented into the toolbar section.
+As soon as this element has been implemented into the map area, a :ref:`button` has to be implemented into the toolbar section.
+Following these instructions, the result in the application looks like this:
 
-The configuration of a button can look like this:
-
-.. image:: ../../../figures/legend_example_button.png
+.. image:: ../../../figures/legend.png
      :scale: 80
 
-Following the above instructions, the result in the application looks like this:
-
-.. image:: ../../../figures/legend_example_toolbar.png
-     :scale: 80
-
-The toolbar shows the button for the legend element. If the button is clicked, the dialog with the generated legend opens.
+The toolbar shows the button for the legend element. If the button is clicked, the dialog with the generated legend opens(will open automatically in our example).
 
 The activation and deactivation of checkboxes in the configurational settings leads to:
 
 .. image:: ../../../figures/legend_example_toolbar_checkboxes.png
-     :width: 100%
+     :scale: 80
 
 YAML-Definition
 ---------------

--- a/en/elements/basic/legend.rst
+++ b/en/elements/basic/legend.rst
@@ -68,7 +68,7 @@ Following these instructions, the result in the application looks like this:
 .. image:: ../../../figures/legend.png
      :scale: 80
 
-The toolbar shows the button for the legend element. If the button is clicked, the dialog with the generated legend opens(will open automatically in our example).
+The toolbar shows the button for the legend element. If the button is clicked, the dialog with the generated legend opens. With the "Open automatically" setting, the dialog is displayed directly when the application is started.
 
 The activation and deactivation of checkboxes in the configurational settings leads to:
 


### PR DESCRIPTION
Deleted 2 Images, by changing their path to 2 existing images, that looked the same and we already had.

In the "Legend in the toolbar" part, the button config screenshot was deleted, because it is explained in detail( in the referred "Button" Element), how to do so.

Maybe discuss this in person, in our meeting, later!