### PR TITLE
Feature/wms assign options

### DIFF
--- a/de/customization/commands.rst
+++ b/de/customization/commands.rst
@@ -508,7 +508,7 @@ Fügt einen im Dienste-Repository stehenden WMS-Dienst einer Mapbender-Anwendung
 
 .. code-block:: yaml
 
-	bin/console mapbender:wms:assign <application> <source> [<layerset>]
+	bin/console mapbender:wms:assign [options] [--] <application> <source> [<layerset>]
 
 
 Konfiguration:
@@ -518,6 +518,22 @@ Konfiguration:
 * `source`: ID des WMS-Dienstes,
 * `layerset` (optional): ID oder Name des Layersets. Der Standardwert ist *main* oder das erste Layerset in der Anwendung.
 
+Folgende zusätzliche Optionen sind möglich:
+
+* -f, --format    Legt das Format für die GetMap-Anfrage fest, z.B. image/png. 
+* -i, --infoformat    Legt das Format für die FeatureInfo-Anfrage fest, z.B. text/html.
+* -p, --proxy    Bestimmt, ob ein Proxy verwendet wird (true | false).
+* -t, --tiled    Gibt an, ob GetMap-Anfragen gekachelt zurückgegeben werden (true | false).
+* -l, --layerorder    Legt die Layer-Reihenfolge fest (standard | reverse) (Hinweis: reverse = QGIS).
+* -h, --help    Zeigt die Hilfe für den angegebenen Befehl an. Wenn kein Befehl angegeben wird, wird die Hilfe für den list-Befehl angezeigt.
+* -q, --quiet    Gibt keine Ausgaben aus.
+* -V, --version    Zeigt die Version der Applikation an.
+* --ansi, --no-ansi    (De-)aktiviert die ANSI-Ausgabe.
+* -n, --no-interaction    Keine interaktiven Rückfragen.
+* -e, --env=UMGEBUNG    Name der Umgebung (Standard: "dev").
+* --no-debug    Schaltet Debug-Modus aus.
+* --profile    Aktiviert Profiling (benötigt Debug-Modus).
+* -v, -vv, -vvv, --verbose    Erhöht die Ausführlichkeit der Ausgaben: 1 für normale Ausgabe, 2 für ausführlichere Ausgabe, 3 für Debug.
 
 bin/console mapbender:wms:parse:url
 ***********************************

--- a/de/customization/commands.rst
+++ b/de/customization/commands.rst
@@ -525,15 +525,6 @@ Folgende zusätzliche Optionen sind möglich:
 * -p, --proxy    Bestimmt, ob ein Proxy verwendet wird (true | false).
 * -t, --tiled    Gibt an, ob GetMap-Anfragen gekachelt zurückgegeben werden (true | false).
 * -l, --layerorder    Legt die Layer-Reihenfolge fest (standard | reverse) (Hinweis: reverse = QGIS).
-* -h, --help    Zeigt die Hilfe für den angegebenen Befehl an. Wenn kein Befehl angegeben wird, wird die Hilfe für den list-Befehl angezeigt.
-* -q, --quiet    Gibt keine Ausgaben aus.
-* -V, --version    Zeigt die Version der Applikation an.
-* --ansi, --no-ansi    (De-)aktiviert die ANSI-Ausgabe.
-* -n, --no-interaction    Keine interaktiven Rückfragen.
-* -e, --env=UMGEBUNG    Name der Umgebung (Standard: "dev").
-* --no-debug    Schaltet Debug-Modus aus.
-* --profile    Aktiviert Profiling (benötigt Debug-Modus).
-* -v, -vv, -vvv, --verbose    Erhöht die Ausführlichkeit der Ausgaben: 1 für normale Ausgabe, 2 für ausführlichere Ausgabe, 3 für Debug.
 
 bin/console mapbender:wms:parse:url
 ***********************************

--- a/en/customization/commands.rst
+++ b/en/customization/commands.rst
@@ -506,7 +506,7 @@ Adds a WMS source instance from the sources repository to a Mapbender applicatio
 
 .. code-block:: yaml
 
-	bin/console mapbender:wms:assign <application> <source> [<layerset>]
+	bin/console mapbender:wms:assign [options] [--] <application> <source> [<layerset>]
 
 Configuration
 -------------
@@ -515,6 +515,22 @@ Configuration
 * `source`: ID of the WMS service,
 * `layerset` (optional): ID or name of the layerset. The default value is *main* or the first layerset in the application.
 
+The following additional options are available:
+
+* -f, --format    Sets the format for the GetMap request, such as image/png.
+* -i, --infoformat    Sets the format for the FeatureInfo request, such as text/html.
+* -p, --proxy    Determines whether a proxy is used (true | false).
+* -t, --tiled    Specifies whether GetMap requests are returned as tiles (true | false).
+* -l, --layerorder    Sets the layer order (standard | reverse) (Note: reverse = QGIS).
+* -h, --help    Displays help for the command. When no command is given display help for the list command.
+* -q, --quiet    Do not output any message.
+* -V, --version    Displays the application version.
+* --ansi, --no-ansi    Force (or disable --no-ansi) ANSI output
+* -n, --no-interaction    Do not ask any interactive questions.
+* -e, --env=ENV    The Environment name. (default: "dev").
+* --no-debug    Switch off debug mode.
+* --profile    Enables profiling (requires debug).
+* -v, -vv, -vvv, --verbose    Increases the verbosity of messages: 1 for normal output, 2 for more verbose output, 3 for debug.
 
 bin/console mapbender:wms:parse:url
 ***********************************

--- a/en/customization/commands.rst
+++ b/en/customization/commands.rst
@@ -522,15 +522,6 @@ The following additional options are available:
 * -p, --proxy    Determines whether a proxy is used (true | false).
 * -t, --tiled    Specifies whether GetMap requests are returned as tiles (true | false).
 * -l, --layerorder    Sets the layer order (standard | reverse) (Note: reverse = QGIS).
-* -h, --help    Displays help for the command. When no command is given display help for the list command.
-* -q, --quiet    Do not output any message.
-* -V, --version    Displays the application version.
-* --ansi, --no-ansi    Force (or disable --no-ansi) ANSI output
-* -n, --no-interaction    Do not ask any interactive questions.
-* -e, --env=ENV    The Environment name. (default: "dev").
-* --no-debug    Switch off debug mode.
-* --profile    Enables profiling (requires debug).
-* -v, -vv, -vvv, --verbose    Increases the verbosity of messages: 1 for normal output, 2 for more verbose output, 3 for debug.
 
 bin/console mapbender:wms:parse:url
 ***********************************


### PR DESCRIPTION
This PR adds a detailed overview of all command-line options for `bin/console mapbender:wms:assign`
All options and descriptions were taken from the --help option of this command.
The description was added in the english and german version.