### PR TITLE
Search router add multi-value search information (Version 5)

### DIFF
--- a/de/elements/search/search_router.rst
+++ b/de/elements/search/search_router.rst
@@ -71,6 +71,11 @@ Hier erfolgt die Definition:
                 required: false
                 label: Ort/Stadt
             compare: ilike
+            multi_value: true
+            multi_value_separators:
+              - ','
+              - ;
+              - '|'            
     results:
         view: table
         count: true
@@ -274,6 +279,22 @@ Folgende Vergleichsmodi werde unterstützt:
 * **not:** nicht (für Type Number, Integer oder Date) Nicht kompatibel mit iexact und allen like-Modi. Auto-Vervollständigung ignoriert diesen Modus.
 
 
+Suche nach mehreren Begriffen ()Multi Value)
+--------------------------------------------
+
+Sie können Felder als multi-value definieren. Dadurch können mehrere Werte für die Suche eingegeben werden. Sie können ein oder mehrere mögliche Trennzeichen definieren.
+
+.. code-block:: yaml
+  
+    multi_value: true
+    multi_value_separators:
+      - ','
+      - ;
+      - '|'
+
+* **multi_value:** Aktiviert die Suche nach mehreren Begriffen für dieses Feld (Standard ist false)
+* **multi_value_separators:** Liste von möglichen Zeichen, zur Trennung der einzelnen Suchbegriffe (Standard ist Komma)
+
 
 Ergebnisausgabe
 ---------------
@@ -424,6 +445,11 @@ Der Elementitel (*Titel*) lautet Suchen, er wird in der Sidepane angezeigt. Da d
           data-autocomplete: 'on'
           data-autocomplete-distinct: 'on'
       compare: ilike
+      multi_value: true
+      multi_value_separators:
+        - ','
+        - ;
+        - '|'      
     usertype:                                                           # Feld für die Suche nach dem Nutzertyp
       type: Symfony\Component\Form\Extension\Core\Type\ChoiceType
       options:

--- a/de/elements/search/search_router.rst
+++ b/de/elements/search/search_router.rst
@@ -279,7 +279,7 @@ Folgende Vergleichsmodi werde unterstützt:
 * **not:** nicht (für Type Number, Integer oder Date) Nicht kompatibel mit iexact und allen like-Modi. Auto-Vervollständigung ignoriert diesen Modus.
 
 
-Suche nach mehreren Begriffen ()Multi Value)
+Suche nach mehreren Begriffen (Multi Value)
 --------------------------------------------
 
 Sie können Felder als multi-value definieren. Dadurch können mehrere Werte für die Suche eingegeben werden. Sie können ein oder mehrere mögliche Trennzeichen definieren.

--- a/en/elements/search/search_router.rst
+++ b/en/elements/search/search_router.rst
@@ -69,6 +69,11 @@ Here, you define all important information for each search:
                 required: false
                 label: City/Town
             compare: ilike
+            multi_value: true
+            multi_value_separators:
+              - ','
+              - ;
+              - '|'
     results:
         view: table
         count: true
@@ -268,6 +273,23 @@ The following comparison modes are supported:
 * **lower-equal:** lower or equal  (for type number, integer or date) Not compatible with all like modes. Auto-complete is ignored.
 * **not:** is not (for type number, integer or date) Not compatible with all like modes. Auto-complete is ignored.
 
+Multi Value Search 
+------------------
+
+You can define multi value fields. If multi-value is activated you can enter more than one search text. You can define one or more possible separator characters.
+
+.. code-block:: yaml
+  
+    multi_value: true
+    multi_value_separators:
+      - ','
+      - ;
+      - '|'
+
+* **multi_value:** activate multi value search for a search field (default is false)
+* **multi_value_separators:** list of characters that are used to separate the different search values (default is comma)
+
+
 Result
 ------
 
@@ -418,6 +440,11 @@ The element title (*Title*) is Search. It is again displayed as a title in the s
           data-autocomplete: 'on'
           data-autocomplete-distinct: 'on'
       compare: ilike
+      multi_value: true
+      multi_value_separators:
+        - ','
+        - ;
+        - '|'         
     usertype:                              # search field (search for specific User type)
       type: Symfony\Component\Form\Extension\Core\Type\ChoiceType
       options:


### PR DESCRIPTION
- search for multiple word in on search requuest

Example

```
    town:                                  # search field (e.g. search for specific city)
      type: Symfony\Component\Form\Extension\Core\Type\TextType
      options:
        required: false                    # no mandatory field
        label: City                        # caption of the search field
        attr:
          data-autocomplete: 'on'
          data-autocomplete-distinct: 'on'
      compare: ilike
      multi_value: true
      multi_value_separators:
        - ','
        - ;
        - '|' 
```